### PR TITLE
fix: proxy all request properties to upstream

### DIFF
--- a/packages/web-fragments/src/gateway/pagesMiddleware.ts
+++ b/packages/web-fragments/src/gateway/pagesMiddleware.ts
@@ -39,9 +39,7 @@ export function getPagesMiddleware(
           matchedFragment.upstream
         );
 
-        return fetch(upstreamUrl, {
-          headers: request.headers
-        });
+        return fetch(upstreamUrl, request);
       }
     }
 


### PR DESCRIPTION
This PR fixes an issue with the gateway Pages middleware where we weren't forwarding all request properties to the upstream (e.g. method, body). Since upstream fragments may be running backend-for-frontend servers, this is a problem since all forwarded requests were coming through as GETs and missing their bodies, etc.