### PR TITLE
improve pierced-react dev mode plus apply other fixes/improvements

### DIFF
--- a/e2e/pierced-react/README.md
+++ b/e2e/pierced-react/README.md
@@ -3,6 +3,4 @@
 To run the app (that shows the server side piercing) you need to run (in order):
 
 - `pnpm i`
-- `pnpm --filter reframed --filter web-fragments --filter pierced-react-remix-fragment build`
-- `pnpm --filter pierced-react-remix-fragment start`
 - in a new terminal: `pnpm --filter pierced-react dev`

--- a/e2e/pierced-react/package.json
+++ b/e2e/pierced-react/package.json
@@ -4,9 +4,7 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
-		"dev": "pnpm run --stream --parallel '/^dev:.*/'",
-		"dev:pages": "wrangler pages dev --binding DEV_MODE=true",
-		"dev:vite": "vite build -w",
+		"dev": "NODE_ENV='development' vite build -w",
 		"build": "tsc -b && vite build",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"preview": "vite preview"

--- a/e2e/pierced-react/vite.config.ts
+++ b/e2e/pierced-react/vite.config.ts
@@ -1,10 +1,54 @@
-import { defineConfig } from "vite";
+import { ChildProcess, spawn, spawnSync } from "node:child_process";
+import { Plugin, defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+
+if (process.env.NODE_ENV === "development") {
+	serveRemixFragment();
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	plugins: [react()],
-	optimizeDeps: {
-		exclude: ["fragment-gateway"],
-	},
+	plugins: [react(), wranglerPagesDevWithReload()],
 });
+
+function wranglerPagesDevWithReload(): Plugin[] {
+	if (process.env.NODE_ENV !== "development") {
+		return [];
+	}
+
+	const runWranglerPagesDev: (() => void) & {
+		pagesDevProcess?: ChildProcess;
+	} = () => {
+		runWranglerPagesDev.pagesDevProcess?.kill();
+		runWranglerPagesDev.pagesDevProcess = spawn(
+			"pnpm",
+			["wrangler", "pages", "dev", "--binding", "DEV_MODE=true"],
+			{ stdio: "inherit" }
+		);
+	};
+
+	return [
+		{
+			name: "pages-functions-external-hot-reload",
+			buildStart() {
+				// we want to watch for changes in the web-fragments/gateway entrypoint
+				this.addWatchFile("../../packages/web-fragments/src/gateway");
+				// after each change lets re-run wrangler pages dev
+				runWranglerPagesDev();
+			},
+		},
+	];
+}
+
+function serveRemixFragment() {
+	// build the remix fragment
+	spawnSync("pnpm", ["--filter", "pierced-react-remix-fragment", "build"], {
+		stdio: "inherit",
+	});
+
+	// serve the remix fragment (in production mode)
+	spawn("pnpm", ["--filter", "pierced-react-remix-fragment", "start"], {
+		stdio: "inherit",
+		env: { ...process.env, NODE_ENV: "production" },
+	});
+}

--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -22,7 +22,7 @@
 			}
 		}
 	},
-	"version": "0.0.2",
+	"version": "0.0.4",
 	"files": [
 		"dist"
 	],

--- a/packages/web-fragments/src/gateway/pagesMiddleware.ts
+++ b/packages/web-fragments/src/gateway/pagesMiddleware.ts
@@ -78,9 +78,12 @@ export function getPagesMiddleware(
 					},
 				});
 
-				const fragmentReq = new Request(upstreamUrl, {
-					...request,
-				});
+				const fragmentReq = new Request(upstreamUrl, request);
+				// Note: we don't want to forward the sec-fetch-dest since we usually need
+				//       custom logic so that we avoid returning full htmls if the header is
+				//       not set to 'document'
+				fragmentReq.headers.set("sec-fetch-dest", "empty");
+
 				let fragmentRes: Response;
 				let fragmentFailedResOrError: Response | unknown | null = null;
 				try {

--- a/packages/web-fragments/src/gateway/pagesMiddleware.ts
+++ b/packages/web-fragments/src/gateway/pagesMiddleware.ts
@@ -78,7 +78,9 @@ export function getPagesMiddleware(
 					},
 				});
 
-				const fragmentReq: RequestInfo = { ...request, url: upstreamUrl };
+				const fragmentReq = new Request(upstreamUrl, {
+					...request,
+				});
 				let fragmentRes: Response;
 				let fragmentFailedResOrError: Response | unknown | null = null;
 				try {


### PR DESCRIPTION
As per the README changes as you can see I've changed the `pierced-react` dx so that you only need to run the `dev` script and nothing else 😃 

what's cool, is that if you make changes in either the app itself` the fragment elements entrypoint or the fragment gateway one, all gets reflected right away 😄 (but you do need to manually refresh the browser)

(the remix fragment does not reload on changes...)

(things might not be 100% perfect, but I think that it's much better than how it was before 😄) 

__

> [!NOTE]
> The CI failure is unrelated, I am addressing that here: https://github.com/web-fragments/web-fragments/pull/14
> (ideally we should merge #14 before merging this 🙂)