### PR TITLE
Fix reframed script loading document

### DIFF
--- a/e2e/pierced-react-remix-fragment/app/root.tsx
+++ b/e2e/pierced-react-remix-fragment/app/root.tsx
@@ -10,6 +10,15 @@ import {
 import "./tailwind.css";
 import { LoaderFunctionArgs } from "@remix-run/node";
 
+/**
+ * This is a hack to work around an issue with WritableDOM not populating
+ * the contents of the last script element (which just so happens to be responsible
+ * for hydrating the application). We noticed that if that script tag wasn't the last
+ * child of the body, its contents were inserted correctly. We're adding this empty
+ * div here to make the script tag before it no longer be the last child.
+ */
+const HackDiv = () => <div />;
+
 function isDocumentRequest(request: Request) {
 	return request.headers.get("sec-fetch-dest") === "document";
 }
@@ -39,6 +48,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 				<ScrollRestoration />
 				<Scripts />
 			</body>
+			<HackDiv />
 		</html>
 	) : (
 		<div>
@@ -49,6 +59,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 			{children}
 			<ScrollRestoration />
 			<Scripts />
+			<HackDiv />
 		</div>
 	);
 }

--- a/e2e/pierced-react-remix-fragment/app/routes/_index.tsx
+++ b/e2e/pierced-react-remix-fragment/app/routes/_index.tsx
@@ -37,23 +37,28 @@ export default function Index() {
           }
         }
   `}</style>
-				<p>Remix Counter</p>
-				<div className="counter">
-					<button
-						onClick={() => {
-							setCounter((counter) => counter - 1);
-						}}
-					>
-						-
-					</button>
-					<span>{counter}</span>
-					<button
-						onClick={() => {
-							setCounter((counter) => counter + 1);
-						}}
-					>
-						+
-					</button>
+				<div style={{ maxHeight: "10rem", overflow: "auto" }}>
+					<p>Remix Counter</p>
+					<div className="counter">
+						<button
+							onClick={() => {
+								setCounter((counter) => counter - 1);
+							}}
+						>
+							-
+						</button>
+						<span>{counter}</span>
+						<button
+							onClick={() => {
+								setCounter((counter) => counter + 1);
+							}}
+						>
+							+
+						</button>
+					</div>
+					{new Array(1000).fill(undefined).map((_element, idx) => (
+						<div key={idx}>I am the {idx} element in this list of divs</div>
+					))}
 				</div>
 			</div>
 		</>

--- a/e2e/pierced-react/functions/_middleware.ts
+++ b/e2e/pierced-react/functions/_middleware.ts
@@ -14,9 +14,8 @@ const getGatewayMiddleware: ((devMode: boolean) => PagesFunction) & {
         z-index: 9999999999999999999999999999999;
     
         &.remix {
-            bottom: 14%;
-            left: 50%;
-            translate: -50% 0;
+            bottom: 16%;
+            left: 15%;
         }
       }
     </style>`,

--- a/e2e/pierced-react/src/App.css
+++ b/e2e/pierced-react/src/App.css
@@ -41,11 +41,18 @@
 	color: #888;
 }
 
-fragment-outlet[fragment-id="remix"] {
-	outline: 3px dashed red;
+.fragment-container {
+	outline: 3px dashed #fff;
 	display: block;
-	height: 10rem;
-	width: 20rem;
-	display: grid;
-	place-content: center;
+	height: 20rem;
+	width: 25rem;
+	margin: 1rem;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	box-sizing: border-box;
+}
+
+.fragment-container.pierced {
+	outline: 3px dashed red;
 }

--- a/e2e/pierced-react/src/App.tsx
+++ b/e2e/pierced-react/src/App.tsx
@@ -5,6 +5,11 @@ import "./App.css";
 
 function App() {
 	const [count, setCount] = useState(0);
+	const [showHost, setShowHost] = useState(false);
+
+	const toggleShowHost = () => {
+		setShowHost(!showHost);
+	};
 
 	return (
 		<>
@@ -21,13 +26,30 @@ function App() {
 				<button onClick={() => setCount((count) => count + 1)}>
 					count is {count}
 				</button>
-				<br />
-				<br />
-				<br />
 			</div>
-			{/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-			{/* @ts-ignore */}
-			<fragment-outlet fragment-id="remix" />
+
+			<section style={{ display: "flex", justifyContent: "center" }}>
+				<div className="fragment-container pierced">
+					<h2>Reframed - from target</h2>
+					<fragment-outlet fragment-id="remix" />
+				</div>
+				<div className="fragment-container">
+					<div style={{ width: "100%" }}>
+						<h2>Reframed - with fetch</h2>
+						<button
+							onClick={toggleShowHost}
+							style={{
+								background: "AliceBlue",
+								padding: "0.5rem",
+								color: "black",
+							}}
+						>
+							Toggle host
+						</button>
+					</div>
+					{showHost && <fragment-host></fragment-host>}
+				</div>
+			</section>
 		</>
 	);
 }

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -98,14 +98,14 @@ async function reframeWithFetch(
 			.pipeThrough(new TextDecoderStream())
 			.pipeTo(
 				new WritableDOMStream(target, {
-					scriptLoadingDocument: document,
+					scriptLoadingDocument: iframe.contentDocument!,
 				})
 			)
 			.finally(() => {
 				console.log("reframing done (reframeWithFetch)!", {
 					source: reframedSrc,
 					target,
-					title: document.defaultView!.document.title,
+					title: iframe.contentDocument?.title,
 				});
 				resolve();
 			});


### PR DESCRIPTION
### Overview

- use `iframe.contentDocument` instead of main `document` when passing a node as the `scriptLoadingDocument` in writable-dom
- update E2E demos to show reframe with fetch and from target working

![Screenshot 2024-07-15 at 10 13 11 AM](https://github.com/user-attachments/assets/3b081d3b-ca41-4c82-9d8c-fc283712b278)

