### PR TITLE
chore: give contents write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:


### PR DESCRIPTION
I think that the release workflow requires write permissions to succeed: https://github.com/web-fragments/web-fragments/actions/runs/9943889963/job/27468690963#step:6:39

Note: I'm adding this to the yaml file as I don't seem to be able to globally set workflow permissions:
![Screenshot 2024-07-15 at 18 31 32](https://github.com/user-attachments/assets/e15226e0-fcc5-44d9-bc59-a54a24547887)

