### PR TITLE
Update `writable-dom`

### DIFF
--- a/.changeset/wild-cougars-juggle.md
+++ b/.changeset/wild-cougars-juggle.md
@@ -1,0 +1,7 @@
+---
+"reframed": patch
+---
+
+Update `writable-dom` to fix empty inline script tag issue
+
+See https://github.com/web-fragments/writable-dom/commit/d8c96af41e71448ace4c8387391bc678dce143bd

--- a/e2e/pierced-react-remix-fragment/app/root.tsx
+++ b/e2e/pierced-react-remix-fragment/app/root.tsx
@@ -10,15 +10,6 @@ import {
 import "./tailwind.css";
 import { LoaderFunctionArgs } from "@remix-run/node";
 
-/**
- * This is a hack to work around an issue with WritableDOM not populating
- * the contents of the last script element (which just so happens to be responsible
- * for hydrating the application). We noticed that if that script tag wasn't the last
- * child of the body, its contents were inserted correctly. We're adding this empty
- * div here to make the script tag before it no longer be the last child.
- */
-const HackDiv = () => <div />;
-
 function isDocumentRequest(request: Request) {
 	return request.headers.get("sec-fetch-dest") === "document";
 }
@@ -48,7 +39,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
 				<ScrollRestoration />
 				<Scripts />
 			</body>
-			<HackDiv />
 		</html>
 	) : (
 		<div>
@@ -59,7 +49,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
 			{children}
 			<ScrollRestoration />
 			<Scripts />
-			<HackDiv />
 		</div>
 	);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,7 +293,7 @@ importers:
         version: 5.3.3(@types/node@20.14.9)
       writable-dom:
         specifier: github:web-fragments/writable-dom#reframed-support
-        version: https://codeload.github.com/web-fragments/writable-dom/tar.gz/2e794f3cb4c6bd1486310adb23ab8f8c15564640
+        version: https://codeload.github.com/web-fragments/writable-dom/tar.gz/d8c96af41e71448ace4c8387391bc678dce143bd
 
   packages/web-fragments:
     dependencies:
@@ -4891,8 +4891,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  writable-dom@https://codeload.github.com/web-fragments/writable-dom/tar.gz/2e794f3cb4c6bd1486310adb23ab8f8c15564640:
-    resolution: {tarball: https://codeload.github.com/web-fragments/writable-dom/tar.gz/2e794f3cb4c6bd1486310adb23ab8f8c15564640}
+  writable-dom@https://codeload.github.com/web-fragments/writable-dom/tar.gz/d8c96af41e71448ace4c8387391bc678dce143bd:
+    resolution: {tarball: https://codeload.github.com/web-fragments/writable-dom/tar.gz/d8c96af41e71448ace4c8387391bc678dce143bd}
     version: 1.0.0
 
   ws@7.5.10:
@@ -10748,7 +10748,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  writable-dom@https://codeload.github.com/web-fragments/writable-dom/tar.gz/2e794f3cb4c6bd1486310adb23ab8f8c15564640: {}
+  writable-dom@https://codeload.github.com/web-fragments/writable-dom/tar.gz/d8c96af41e71448ace4c8387391bc678dce143bd: {}
 
   ws@7.5.10: {}
 


### PR DESCRIPTION
This PR updates `writable-dom` to https://github.com/web-fragments/writable-dom/commit/d8c96af41e71448ace4c8387391bc678dce143bd, which removes the need to append an extra `<div />` to the end of a fragment in order to get its final `<script>` element's child nodes populated correctly.