### PR TITLE
fix: prevent piercing FOUC

### DIFF
--- a/.changeset/strange-candles-fail.md
+++ b/.changeset/strange-candles-fail.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+Prevented the FOUC when piercing into fragment-outlet

--- a/packages/web-fragments/src/elements/fragment-host.ts
+++ b/packages/web-fragments/src/elements/fragment-host.ts
@@ -69,6 +69,9 @@ export class FragmentHost extends HTMLElement {
 		// We need to do the same when we move <fragment-host> into <fragment-outlet>
 		this.neutralizeScriptTags();
 
+		// Preserve the existing stylesheets to avoid a FOUC when reinserting this element into the DOM
+		this.preserveStylesheets();
+
 		// Move <fragment-host> into <fragment-outlet> and set a flag to return early in the disconnectedCallback
 		this.isPortaling = true;
 		const hostElement = event.target as HTMLElement;
@@ -77,6 +80,19 @@ export class FragmentHost extends HTMLElement {
 		// Restore the initial type attributes of the script tags
 		this.restoreScriptTags();
 		this.removeAttribute("data-piercing");
+	}
+
+	preserveStylesheets() {
+		if (this.shadowRoot) {
+			this.shadowRoot.adoptedStyleSheets = Array.from(
+				this.shadowRoot.styleSheets,
+				(sheet) => {
+					const clone = new CSSStyleSheet();
+					[...sheet.cssRules].forEach((rule) => clone.insertRule(rule.cssText));
+					return clone;
+				}
+			);
+		}
 	}
 
 	neutralizeScriptTags() {


### PR DESCRIPTION
This PR prevents a FOUC when piercing a fragment-host into a fragment-outlet.

When the fragment-host is removed from the DOM and reinserted, its existing stylesheets are destroyed and reloaded, which results in a flash-of-unstyled-content while the styles are being refetched. We now preserve these existing styles by cloning them into new constructable stylesheets and assigning them to `ShadowRoot.adoptedStyleSheets` before reparenting the fragment-host.

