### PR TITLE
feat: extend onSSRFetchError to support overriding the entire response

### DIFF
--- a/.changeset/silver-swans-jog.md
+++ b/.changeset/silver-swans-jog.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+Add support for overriding response in onSSRFetchError

--- a/e2e/pierced-react/functions/_middleware.ts
+++ b/e2e/pierced-react/functions/_middleware.ts
@@ -29,10 +29,12 @@ const getGatewayMiddleware: ((devMode: boolean) => PagesFunction) & {
 		// Note: the pierced-react-remix-fragment has to be available on port 3000
 		upstream: "http://localhost:3000",
 		onSsrFetchError: () => {
-			return new Response(
-				"<p id='remix-fragment-not-found'><style>#remix-fragment-not-found { color: red; font-size: 2rem; }</style>Remix fragment not found</p>",
-				{ headers: [["content-type", "text/html"]] }
-			);
+			return {
+				response: new Response(
+					"<p id='remix-fragment-not-found'><style>#remix-fragment-not-found { color: red; font-size: 2rem; }</style>Remix fragment not found</p>",
+					{ headers: [["content-type", "text/html"]] }
+				),
+			};
 		},
 	});
 
@@ -43,10 +45,12 @@ const getGatewayMiddleware: ((devMode: boolean) => PagesFunction) & {
 		// Note: the pierced-react-qwik-fragment has to be available on port 8123
 		upstream: "http://localhost:8123",
 		onSsrFetchError: () => {
-			return new Response(
-				"<p id='qwik-fragment-not-found'><style>#qwik-fragment-not-found { color: red; font-size: 2rem; }</style>Qwik fragment not found</p>",
-				{ headers: [["content-type", "text/html"]] }
-			);
+			return {
+				response: new Response(
+					"<p id='qwik-fragment-not-found'><style>#qwik-fragment-not-found { color: red; font-size: 2rem; }</style>Qwik fragment not found</p>",
+					{ headers: [["content-type", "text/html"]] }
+				),
+			};
 		},
 	});
 

--- a/packages/web-fragments/src/gateway/fragment-gateway.ts
+++ b/packages/web-fragments/src/gateway/fragment-gateway.ts
@@ -1,5 +1,10 @@
 import { MatchFunction, match } from "path-to-regexp";
 
+interface SSRFetchErrorResponse {
+	response: Response;
+	overrideResponse?: boolean;
+}
+
 /**
  * Configuration object for the registration of a fragment in the app's gateway worker.
  */
@@ -39,7 +44,7 @@ export interface FragmentConfig {
 	onSsrFetchError?: (
 		req: RequestInfo,
 		failedResOrError: Response | unknown
-	) => Response | Promise<Response>;
+	) => SSRFetchErrorResponse | Promise<SSRFetchErrorResponse>;
 }
 
 type FragmentGatewayConfig = {


### PR DESCRIPTION
### Overview

For scenarios where you want to completely override the response when an SSR fetch for a fragment fails, we need to add an additional flag that's returned by the onSSRFetchError callback so that the Pages middleware can either return the response or embed it in the initial request to the origin.