### PR TITLE
Improvements to make sure that qwik's `useVisibleTask$` can successfully fire

### DIFF
--- a/.changeset/brown-lies-divide.md
+++ b/.changeset/brown-lies-divide.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+fix: patch the iframe's document `readyState` (and also dispatch `readystatechange` event)

--- a/.changeset/cuddly-shrimps-fly.md
+++ b/.changeset/cuddly-shrimps-fly.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+fix: patch iframe's window `IntersectionObserver`

--- a/.changeset/tidy-paws-develop.md
+++ b/.changeset/tidy-paws-develop.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+fix: remove unnecessary `qinit` dispatching from `fragment-outlet`

--- a/e2e/pierced-react/fragments/qwik/src/routes/qwik-page/index.tsx
+++ b/e2e/pierced-react/fragments/qwik/src/routes/qwik-page/index.tsx
@@ -1,8 +1,17 @@
-import { component$, useSignal, useStyles$ } from "@builder.io/qwik";
+import {
+	component$,
+	useSignal,
+	useStyles$,
+	useVisibleTask$,
+} from "@builder.io/qwik";
 import type { DocumentHead } from "@builder.io/qwik-city";
 
 export default component$(() => {
 	const counter = useSignal(0);
+
+	useVisibleTask$(() => {
+		counter.value += 50;
+	});
 
 	useStyles$(`
     .qwik-counter-page {

--- a/e2e/qwik-app/package.json
+++ b/e2e/qwik-app/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "my-qwik-basic-starter",
+	"name": "qwik-app",
 	"description": "Demo App with Routing built-in (recommended)",
 	"engines": {
 		"node": "^18.17.0 || ^20.3.0 || >=21.0.0"

--- a/e2e/qwik-app/src/routes/index.tsx
+++ b/e2e/qwik-app/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { component$, useOnDocument, $ } from "@builder.io/qwik";
+import { component$, useVisibleTask$ } from "@builder.io/qwik";
 import type { DocumentHead } from "@builder.io/qwik-city";
 
 import { reframed } from "reframed";
@@ -9,14 +9,12 @@ import Infobox from "../components/starter/infobox/infobox";
 import Starter from "../components/starter/next-steps/next-steps";
 
 export default component$(() => {
-	useOnDocument(
-		"DOMContentLoaded",
-		$(async () => {
-			if ((document as any).unreframedBody) return;
-			const reframedContainer = document.getElementById("flower")!;
-			await reframed("/demo/flower/blue", { container: reframedContainer });
-		})
-	);
+	// eslint-disable-next-line qwik/no-use-visible-task
+	useVisibleTask$(() => {
+		if ((document as any).unreframedBody) return;
+		const reframedContainer = document.getElementById("flower")!;
+		reframed("/demo/flower/blue", { container: reframedContainer });
+	});
 
 	return (
 		<>

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -16,16 +16,26 @@ export function reframed(
 	iframe: HTMLIFrameElement;
 	container: HTMLElement;
 	// TODO: revert back to Promise<void> once ready promise is cleaned up
-	ready: Promise<[() => void, void]>;
+	ready: Promise<() => void>;
 } {
+	const reframeMetadata: ReframedMetadata = {
+		iframeDocumentReadyState: "loading",
+	};
+
 	// create the reframed container
-	const reframedContainer =
+	const reframedContainer = (
 		"container" in options
 			? options.container
-			: document.createElement(options.containerTagName);
-	const reframedContainerShadowRoot =
+			: document.createElement(options.containerTagName)
+	) as ReframedContainer;
+
+	const reframedContainerShadowRoot = Object.assign(
 		reframedContainer.shadowRoot ??
-		reframedContainer.attachShadow({ mode: "open" });
+			reframedContainer.attachShadow({ mode: "open" }),
+		{
+			[reframedMetadataSymbol]: reframeMetadata,
+		}
+	);
 
 	/**
 	 * Create the iframe that we'll use to load scripts into, but hide it from the viewport.
@@ -77,10 +87,34 @@ export function reframed(
 	//       has added the various load event listeners
 	document.body.insertAdjacentElement("beforeend", iframe);
 
+	const ready = Promise.all([monkeyPatchReady, reframeReady]).then(
+		([cleanup]) => {
+			reframedContainer.shadowRoot[
+				reframedMetadataSymbol
+			].iframeDocumentReadyState = "interactive";
+			reframedContainer.shadowRoot!.dispatchEvent(
+				new Event("readystatechange")
+			);
+			// TODO: this should be called when reframed async loading activities finish
+			//        (note: the 2s delay is completely arbitrary, this is a very temporary solution anyways)
+			//       (see: https://github.com/web-fragments/web-fragments/issues/36)
+			setTimeout(() => {
+				reframedContainer.shadowRoot[
+					reframedMetadataSymbol
+				].iframeDocumentReadyState = "complete";
+				reframedContainer.shadowRoot.dispatchEvent(
+					new Event("readystatechange")
+				);
+			}, 2_000);
+
+			return cleanup;
+		}
+	);
+
 	return {
 		iframe,
 		container: reframedContainer,
-		ready: Promise.all([monkeyPatchReady, reframeReady]),
+		ready,
 	};
 }
 
@@ -175,7 +209,7 @@ async function reframeFromTarget(
  */
 function monkeyPatchIFrameDocument(
 	iframeDocument: Document,
-	shadowRoot: ShadowRoot
+	shadowRoot: ReframedShadowRoot
 ): () => void {
 	const iframeDocumentPrototype = Object.getPrototypeOf(
 		Object.getPrototypeOf(iframeDocument)
@@ -204,6 +238,20 @@ function monkeyPatchIFrameDocument(
 			},
 			set: function (newTitle: string) {
 				updatedIframeTitle = newTitle;
+			},
+		},
+
+		readyState: {
+			get() {
+				if (
+					shadowRoot[reframedMetadataSymbol].iframeDocumentReadyState ===
+					"complete"
+				) {
+					console.warn(
+						"reframed warning: `document.readyState` possibly returned `'complete'` prematurely. If your app is not working correctly, please see https://github.com/web-fragments/web-fragments/issues/36  and comment on this issue so that we can prioritize fixing it."
+					);
+				}
+				return shadowRoot[reframedMetadataSymbol].iframeDocumentReadyState;
 			},
 		},
 
@@ -545,3 +593,23 @@ function isReframedDocument(
 ): document is ReframedDocument {
 	return "unreframedBody" in document;
 }
+
+type ReframedMetadata = {
+	/**
+	 * Indicates what the value the iframe's document readyState should be.
+	 *
+	 * Note that we can't simply monkey patch this to the main document (since the iframe needs to have its own behavior regarding this state),
+	 * so we need to directly manage this state ourselves.
+	 */
+	iframeDocumentReadyState: DocumentReadyState;
+};
+
+const reframedMetadataSymbol = Symbol("reframedMetadata");
+
+type ReframedShadowRoot = ShadowRoot & {
+	[reframedMetadataSymbol]: ReframedMetadata;
+};
+
+type ReframedContainer = HTMLElement & {
+	shadowRoot: ReframedShadowRoot;
+};

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -367,6 +367,8 @@ function monkeyPatchIFrameDocument(
 		},
 	} satisfies Record<keyof Document, any>);
 
+	iframeWindow.IntersectionObserver = mainWindow.IntersectionObserver;
+
 	const domCreateProperties: (keyof Pick<
 		Document,
 		| "createAttributeNS"

--- a/packages/web-fragments/src/elements/fragment-host.ts
+++ b/packages/web-fragments/src/elements/fragment-host.ts
@@ -2,7 +2,7 @@ import { reframed } from "reframed";
 
 export class FragmentHost extends HTMLElement {
 	iframe: HTMLIFrameElement | undefined;
-	ready: Promise<[() => void, void]> | undefined;
+	ready: Promise<() => void> | undefined;
 	isInitialized = false;
 	isPortaling = false;
 
@@ -48,7 +48,7 @@ export class FragmentHost extends HTMLElement {
 		// TODO: Figure out a better way to handle restoring side effects from calling reframed()
 		// It feels wrong for the fragment-host to handle this in the disconnected callback
 		if (this.ready) {
-			const [restoreMonkeyPatchSideEffects] = await this.ready;
+			const restoreMonkeyPatchSideEffects = await this.ready;
 			restoreMonkeyPatchSideEffects();
 		}
 

--- a/packages/web-fragments/src/elements/fragment-outlet.ts
+++ b/packages/web-fragments/src/elements/fragment-outlet.ts
@@ -22,12 +22,6 @@ export class FragmentOutlet extends HTMLElement {
 			const fragmentHost = document.createElement("fragment-host");
 			this.appendChild(fragmentHost);
 		}
-
-		// We need to dispatch a qinit so that Qwik can run different necessary
-		// checks/logic on Qwik fragments (which it would otherwise not with this
-		// fragments implementation).
-		// (for more info see: https://github.com/BuilderIO/qwik/issues/1947)
-		document.dispatchEvent(new Event("qinit"));
 	}
 
 	disconnectedCallback() {


### PR DESCRIPTION
This PR fixes the server side piercing not triggering qwik fragment's `useVisibleTask$` calls

it does so by: 
 - patching the iframe's document `readyState`
 - pathing the iframe's `IntersectionObserver`
 
it also:
 - removes the `fragmet-outlet` dispatching of a `qinit` event, since I don't think that that is actually needed
   (we can re-introduce it later if need be)