### PR TITLE
Patch DOM insertion methods to execute inserted scripts in reframed context

### DIFF
--- a/.changeset/six-beds-check.md
+++ b/.changeset/six-beds-check.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+DOM insertion methods now result in inserted scripts being executed in the reframed context.


### PR DESCRIPTION
This PR fixes an issue where scripts inserted into the main document by code running in the reframed context were being executed in the main context (escaping the reframed sandbox).

We now patch any DOM insertion methods that have to potential to result in script execution to insert script elements into the reframed document instead. By executing scripts in the reframed context first, we don't need to try to make them inert in other ways (e.g. changing the `type` attribute) before inserting them into the main document. We can take advantage of scripts having exactly-once execution semantics.

Scripts have an internal `already started` flag that keeps track of whether they've been executed, and this flag is copied when cloning the element. Our approach is to clone the script, execute the clone by inserting it into the reframed document, then swap the original script element with (yet another clone of) the now-executed script. We can then proceed with whatever DOM insertion operation as normal, knowing the script won't be re-executed because its `already started` is true.