### PR TITLE
fix: DOM insertion method patching v2

### DIFF
--- a/.changeset/smart-rocks-tease.md
+++ b/.changeset/smart-rocks-tease.md
@@ -4,4 +4,4 @@
 
 Another attempt at fixing DOM insertion method patching.
 
-Our previous assumptions in [#42](https://github.com/web-fragments/web-fragments/pull/42) turned out to be wrong. We do indeed need to patch the main execution context's insertion methods. We now patch them to check if the node the insertion method is being called on is within a reframed container, and if so execute any potential script elements within the associated reframed context.
+Our previous assumptions in [#42](https://github.com/web-fragments/web-fragments/pull/42) turned out to be wrong. We do indeed need to patch the main execution context's insertion methods. We now patch them to check if the node the insertion method is being called on is within a reframed container, and if so execute any potential script elements within the associated reframed context. Note that loading `reframed` is now side-effectful.

--- a/.changeset/smart-rocks-tease.md
+++ b/.changeset/smart-rocks-tease.md
@@ -1,0 +1,7 @@
+---
+"reframed": patch
+---
+
+Another attempt at fixing DOM insertion method patching.
+
+Our previous assumptions in [#42](https://github.com/web-fragments/web-fragments/pull/42) turned out to be wrong. We do indeed need to patch the main execution context's insertion methods. We now patch them to check if the node the insertion method is being called on is within a reframed container, and if so execute any potential script elements within the associated reframed context.

--- a/e2e/pierced-react/fragments/remix/app/routes/remix-page_.details.tsx
+++ b/e2e/pierced-react/fragments/remix/app/routes/remix-page_.details.tsx
@@ -1,6 +1,7 @@
 import type { MetaFunction } from "@remix-run/node";
-import { useState } from "react";
-import { Link } from "@remix-run/react";
+import { Suspense } from "react";
+import { Link, useLoaderData, Await } from "@remix-run/react";
+import { defer } from "@remix-run/node";
 
 export const meta: MetaFunction = () => {
 	return [
@@ -9,8 +10,21 @@ export const meta: MetaFunction = () => {
 	];
 };
 
+export const loader = async () => {
+	const pendingStatus = () =>
+		new Promise<string>((resolve) => {
+			setTimeout(() => {
+				resolve("ok");
+			}, 500);
+		});
+
+	return defer({
+		status: pendingStatus(),
+	});
+};
+
 export default function Index() {
-	const [counter, setCounter] = useState(0);
+	const data = useLoaderData<typeof loader>();
 
 	return (
 		<>
@@ -56,26 +70,11 @@ export default function Index() {
 						</Link>
 					</div>
 					<p>Current Route: /remix-page/details</p>
-					<div className="counter">
-						<button
-							onClick={() => {
-								setCounter((counter) => counter - 1);
-							}}
-						>
-							-
-						</button>
-						<span>{counter}</span>
-						<button
-							onClick={() => {
-								setCounter((counter) => counter + 1);
-							}}
-						>
-							+
-						</button>
-					</div>
-					{new Array(1000).fill(undefined).map((_element, idx) => (
-						<div key={idx}>I am the {idx} element in this list of divs</div>
-					))}
+					<Suspense fallback={<p>Pending status...</p>}>
+						<Await resolve={data.status}>
+							{(status) => <p>Success status: {status}</p>}
+						</Await>
+					</Suspense>
 				</div>
 			</div>
 		</>

--- a/packages/reframed/package.json
+++ b/packages/reframed/package.json
@@ -9,7 +9,9 @@
 	"files": [
 		"dist"
 	],
-	"sideEffects": false,
+	"sideEffects": [
+		"dist/reframed.js"
+	],
 	"license": "MIT",
 	"devDependencies": {
 		"writable-dom": "github:web-fragments/writable-dom#reframed-support",

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -481,7 +481,7 @@ function monkeyPatchIFrameDocument(
 	// Note: methods that parse text containing HTML (e.g. `Element.insertAdjacentHTML()`,
 	// `Element.setHTMLUnsafe()`) do not execute any parsed script elements,
 	// so they do not need to be patched.
-	const _Element__replaceWith = iframeWindow.Element.prototype.replaceWith;
+	const _Element__replaceWith = Element.prototype.replaceWith;
 
 	// This function relies on the fact that scripts follow exactly-once execution semantics.
 	// Scripts contain an internal `already started` flag to track whether they have already
@@ -505,8 +505,8 @@ function monkeyPatchIFrameDocument(
 		scripts.forEach(executeScriptInReframedContext);
 	}
 
-	const _Node__appendChild = iframeWindow.Node.prototype.appendChild;
-	iframeWindow.Node.prototype.appendChild = function appendChild(node) {
+	const _Node__appendChild = Node.prototype.appendChild;
+	Node.prototype.appendChild = function appendChild(node) {
 		executeAnyChildScripts(node);
 		if (node instanceof HTMLScriptElement) {
 			node = arguments[0] = executeScriptInReframedContext(node);
@@ -514,11 +514,8 @@ function monkeyPatchIFrameDocument(
 		return _Node__appendChild.apply(this, arguments as any) as any;
 	};
 
-	const _Node__insertBefore = iframeWindow.Node.prototype.insertBefore;
-	iframeWindow.Node.prototype.insertBefore = function insertBefore(
-		node,
-		child
-	) {
+	const _Node__insertBefore = Node.prototype.insertBefore;
+	Node.prototype.insertBefore = function insertBefore(node, child) {
 		executeAnyChildScripts(node);
 		if (node instanceof HTMLScriptElement) {
 			node = arguments[0] = executeScriptInReframedContext(node);
@@ -526,11 +523,8 @@ function monkeyPatchIFrameDocument(
 		return _Node__insertBefore.apply(this, arguments as any) as any;
 	};
 
-	const _Node__replaceChild = iframeWindow.Node.prototype.replaceChild;
-	iframeWindow.Node.prototype.replaceChild = function replaceChild(
-		node,
-		child
-	) {
+	const _Node__replaceChild = Node.prototype.replaceChild;
+	Node.prototype.replaceChild = function replaceChild(node, child) {
 		executeAnyChildScripts(node);
 		if (node instanceof HTMLScriptElement) {
 			node = arguments[0] = executeScriptInReframedContext(node);
@@ -538,8 +532,8 @@ function monkeyPatchIFrameDocument(
 		return _Node__replaceChild.apply(this, arguments as any) as any;
 	};
 
-	const _Element__after = iframeWindow.Element.prototype.after;
-	iframeWindow.Element.prototype.after = function after(...nodes) {
+	const _Element__after = Element.prototype.after;
+	Element.prototype.after = function after(...nodes) {
 		nodes.forEach((node, index) => {
 			if (typeof node !== "string") {
 				executeAnyChildScripts(node);
@@ -551,8 +545,8 @@ function monkeyPatchIFrameDocument(
 		return _Element__after.apply(this, arguments as any) as any;
 	};
 
-	const _Element__append = iframeWindow.Element.prototype.append;
-	iframeWindow.Element.prototype.append = function append(...nodes) {
+	const _Element__append = Element.prototype.append;
+	Element.prototype.append = function append(...nodes) {
 		nodes.forEach((node, index) => {
 			if (typeof node !== "string") {
 				executeAnyChildScripts(node);
@@ -565,21 +559,20 @@ function monkeyPatchIFrameDocument(
 	};
 
 	const _Element__insertAdjacentElement =
-		iframeWindow.Element.prototype.insertAdjacentElement;
-	iframeWindow.Element.prototype.insertAdjacentElement =
-		function insertAdjacentElement(where, element) {
-			executeAnyChildScripts(element);
-			if (element instanceof HTMLScriptElement) {
-				element = arguments[1] = executeScriptInReframedContext(element);
-			}
-			return _Element__insertAdjacentElement.apply(
-				this,
-				arguments as any
-			) as any;
-		};
+		Element.prototype.insertAdjacentElement;
+	Element.prototype.insertAdjacentElement = function insertAdjacentElement(
+		where,
+		element
+	) {
+		executeAnyChildScripts(element);
+		if (element instanceof HTMLScriptElement) {
+			element = arguments[1] = executeScriptInReframedContext(element);
+		}
+		return _Element__insertAdjacentElement.apply(this, arguments as any) as any;
+	};
 
-	const _Element__prepend = iframeWindow.Element.prototype.prepend;
-	iframeWindow.Element.prototype.prepend = function prepend(...nodes) {
+	const _Element__prepend = Element.prototype.prepend;
+	Element.prototype.prepend = function prepend(...nodes) {
 		nodes.forEach((node, index) => {
 			if (typeof node !== "string") {
 				executeAnyChildScripts(node);
@@ -591,11 +584,8 @@ function monkeyPatchIFrameDocument(
 		return _Element__prepend.apply(this, arguments as any) as any;
 	};
 
-	const _Element__replaceChildren =
-		iframeWindow.Element.prototype.replaceChildren;
-	iframeWindow.Element.prototype.replaceChildren = function replaceChildren(
-		...nodes
-	) {
+	const _Element__replaceChildren = Element.prototype.replaceChildren;
+	Element.prototype.replaceChildren = function replaceChildren(...nodes) {
 		nodes.forEach((node, index) => {
 			if (typeof node !== "string") {
 				executeAnyChildScripts(node);
@@ -607,7 +597,7 @@ function monkeyPatchIFrameDocument(
 		return _Element__replaceChildren.apply(this, arguments as any) as any;
 	};
 
-	iframeWindow.Element.prototype.replaceWith = function replaceWith(...nodes) {
+	Element.prototype.replaceWith = function replaceWith(...nodes) {
 		nodes.forEach((node, index) => {
 			if (typeof node !== "string") {
 				executeAnyChildScripts(node);
@@ -618,7 +608,6 @@ function monkeyPatchIFrameDocument(
 		});
 		return _Element__replaceWith.apply(this, arguments as any) as any;
 	};
-
 	// methods to manage window event listeners
 	const mainWindowEventListeners: Parameters<Window["addEventListener"]>[] = [];
 	Object.defineProperties(Object.getPrototypeOf(iframeWindow), {

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -17,8 +17,17 @@ export function reframed(
 	container: HTMLElement;
 	ready: Promise<() => void>;
 } {
+	/**
+	 * Create the iframe that we'll use to load scripts into, but hide it from the viewport.
+	 * It's important that we set the src of the iframe before we insert the element into the body
+	 * in order to prevent loading the iframe twice when the src is changed later on.
+	 */
+	const iframe = document.createElement("iframe");
+	iframe.hidden = true;
+
 	const reframeMetadata: ReframedMetadata = {
 		iframeDocumentReadyState: "loading",
+		iframe,
 	};
 
 	// create the reframed container
@@ -35,14 +44,6 @@ export function reframed(
 			[reframedMetadataSymbol]: reframeMetadata,
 		}
 	);
-
-	/**
-	 * Create the iframe that we'll use to load scripts into, but hide it from the viewport.
-	 * It's important that we set the src of the iframe before we insert the element into the body
-	 * in order to prevent loading the iframe twice when the src is changed later on.
-	 */
-	const iframe = document.createElement("iframe");
-	iframe.hidden = true;
 
 	/**
 	 * Initialize a promise and resolver for monkeyPatchIFrameDocument.
@@ -477,137 +478,6 @@ function monkeyPatchIFrameDocument(
 		});
 	}
 
-	// Patch DOM insertion methods to execute scripts in reframed context
-	// Note: methods that parse text containing HTML (e.g. `Element.insertAdjacentHTML()`,
-	// `Element.setHTMLUnsafe()`) do not execute any parsed script elements,
-	// so they do not need to be patched.
-	const _Element__replaceWith = Element.prototype.replaceWith;
-
-	// This function relies on the fact that scripts follow exactly-once execution semantics.
-	// Scripts contain an internal `already started` flag to track whether they have already
-	// been executed, and this flag survives cloning operations. So, this function ensures
-	// that the exactly-once execution happens in the reframed context, then replaces the original
-	// script instance with its already-executed clone in whatever node tree it might be within.
-	// It also returns the already-executed clone so that the caller can update any
-	// direct references they might be holding that point to the original script.
-	function executeScriptInReframedContext<T extends Node>(
-		script: T & HTMLScriptElement
-	) {
-		const scriptToExecute = iframeDocument.importNode(script, true);
-		unpatchedIframeBody.appendChild(scriptToExecute);
-		const alreadyStartedScript = document.importNode(scriptToExecute, true);
-		_Element__replaceWith.call(script, alreadyStartedScript);
-		return alreadyStartedScript;
-	}
-
-	function executeAnyChildScripts(element: Node) {
-		const scripts = (element as Element).querySelectorAll?.("script") ?? [];
-		scripts.forEach(executeScriptInReframedContext);
-	}
-
-	const _Node__appendChild = Node.prototype.appendChild;
-	Node.prototype.appendChild = function appendChild(node) {
-		executeAnyChildScripts(node);
-		if (node instanceof HTMLScriptElement) {
-			node = arguments[0] = executeScriptInReframedContext(node);
-		}
-		return _Node__appendChild.apply(this, arguments as any) as any;
-	};
-
-	const _Node__insertBefore = Node.prototype.insertBefore;
-	Node.prototype.insertBefore = function insertBefore(node, child) {
-		executeAnyChildScripts(node);
-		if (node instanceof HTMLScriptElement) {
-			node = arguments[0] = executeScriptInReframedContext(node);
-		}
-		return _Node__insertBefore.apply(this, arguments as any) as any;
-	};
-
-	const _Node__replaceChild = Node.prototype.replaceChild;
-	Node.prototype.replaceChild = function replaceChild(node, child) {
-		executeAnyChildScripts(node);
-		if (node instanceof HTMLScriptElement) {
-			node = arguments[0] = executeScriptInReframedContext(node);
-		}
-		return _Node__replaceChild.apply(this, arguments as any) as any;
-	};
-
-	const _Element__after = Element.prototype.after;
-	Element.prototype.after = function after(...nodes) {
-		nodes.forEach((node, index) => {
-			if (typeof node !== "string") {
-				executeAnyChildScripts(node);
-				if (node instanceof HTMLScriptElement) {
-					node = arguments[index] = executeScriptInReframedContext(node);
-				}
-			}
-		});
-		return _Element__after.apply(this, arguments as any) as any;
-	};
-
-	const _Element__append = Element.prototype.append;
-	Element.prototype.append = function append(...nodes) {
-		nodes.forEach((node, index) => {
-			if (typeof node !== "string") {
-				executeAnyChildScripts(node);
-				if (node instanceof HTMLScriptElement) {
-					node = arguments[index] = executeScriptInReframedContext(node);
-				}
-			}
-		});
-		return _Element__append.apply(this, arguments as any) as any;
-	};
-
-	const _Element__insertAdjacentElement =
-		Element.prototype.insertAdjacentElement;
-	Element.prototype.insertAdjacentElement = function insertAdjacentElement(
-		where,
-		element
-	) {
-		executeAnyChildScripts(element);
-		if (element instanceof HTMLScriptElement) {
-			element = arguments[1] = executeScriptInReframedContext(element);
-		}
-		return _Element__insertAdjacentElement.apply(this, arguments as any) as any;
-	};
-
-	const _Element__prepend = Element.prototype.prepend;
-	Element.prototype.prepend = function prepend(...nodes) {
-		nodes.forEach((node, index) => {
-			if (typeof node !== "string") {
-				executeAnyChildScripts(node);
-				if (node instanceof HTMLScriptElement) {
-					node = arguments[index] = executeScriptInReframedContext(node);
-				}
-			}
-		});
-		return _Element__prepend.apply(this, arguments as any) as any;
-	};
-
-	const _Element__replaceChildren = Element.prototype.replaceChildren;
-	Element.prototype.replaceChildren = function replaceChildren(...nodes) {
-		nodes.forEach((node, index) => {
-			if (typeof node !== "string") {
-				executeAnyChildScripts(node);
-				if (node instanceof HTMLScriptElement) {
-					node = arguments[index] = executeScriptInReframedContext(node);
-				}
-			}
-		});
-		return _Element__replaceChildren.apply(this, arguments as any) as any;
-	};
-
-	Element.prototype.replaceWith = function replaceWith(...nodes) {
-		nodes.forEach((node, index) => {
-			if (typeof node !== "string") {
-				executeAnyChildScripts(node);
-				if (node instanceof HTMLScriptElement) {
-					node = arguments[index] = executeScriptInReframedContext(node);
-				}
-			}
-		});
-		return _Element__replaceWith.apply(this, arguments as any) as any;
-	};
 	// methods to manage window event listeners
 	const mainWindowEventListeners: Parameters<Window["addEventListener"]>[] = [];
 	Object.defineProperties(Object.getPrototypeOf(iframeWindow), {
@@ -774,6 +644,224 @@ function monkeyPatchIFrameDocument(
 	return cleanup;
 }
 
+function monkeyPatchDOMInsertionMethods() {
+	// Patch DOM insertion methods to execute scripts in reframed context
+	// Note: methods that parse text containing HTML (e.g. `Element.insertAdjacentHTML()`,
+	// `Element.setHTMLUnsafe()`) do not execute any parsed script elements,
+	// so they do not need to be patched.
+	const _Element__replaceWith = Element.prototype.replaceWith;
+
+	// This function relies on the fact that scripts follow exactly-once execution semantics.
+	// Scripts contain an internal `already started` flag to track whether they have already
+	// been executed, and this flag survives cloning operations. So, this function ensures
+	// that the exactly-once execution happens in the reframed context, then replaces the original
+	// script instance with its already-executed clone in whatever node tree it might be within.
+	// It also returns the already-executed clone so that the caller can update any
+	// direct references they might be holding that point to the original script.
+	function executeScriptInReframedContext<T extends Node>(
+		script: T & HTMLScriptElement,
+		reframedContext: ReframedMetadata
+	) {
+		const iframe = reframedContext.iframe;
+		assert(
+			iframe.contentDocument !== null,
+			"iframe.contentDocument is not defined"
+		);
+		const scriptToExecute = iframe.contentDocument.importNode(script, true);
+		(iframe.contentDocument as ReframedDocument).unreframedBody.appendChild(
+			scriptToExecute
+		);
+		const alreadyStartedScript = document.importNode(scriptToExecute, true);
+		_Element__replaceWith.call(script, alreadyStartedScript);
+		return alreadyStartedScript;
+	}
+
+	function executeAnyChildScripts(
+		element: Node,
+		reframedContext: ReframedMetadata
+	) {
+		const scripts = (element as Element).querySelectorAll?.("script") ?? [];
+		scripts.forEach((script) =>
+			executeScriptInReframedContext(script, reframedContext)
+		);
+	}
+
+	function isWithinReframedDOM(node: Node) {
+		const root = node.getRootNode();
+		return isReframedShadowRoot(root);
+	}
+
+	function getReframedMetadata(node: Node) {
+		const root = node.getRootNode();
+
+		if (!isReframedShadowRoot(root)) {
+			throw new Error("Missing reframed metadata!");
+		}
+
+		return root[reframedMetadataSymbol];
+	}
+
+	const _Node__appendChild = Node.prototype.appendChild;
+	Node.prototype.appendChild = function appendChild(node) {
+		if (isWithinReframedDOM(this)) {
+			const reframedContext = getReframedMetadata(this);
+			executeAnyChildScripts(node, reframedContext);
+			if (node instanceof HTMLScriptElement) {
+				node = arguments[0] = executeScriptInReframedContext(
+					node,
+					reframedContext
+				);
+			}
+		}
+		return _Node__appendChild.apply(this, arguments as any) as any;
+	};
+
+	const _Node__insertBefore = Node.prototype.insertBefore;
+	Node.prototype.insertBefore = function insertBefore(node, child) {
+		if (isWithinReframedDOM(this)) {
+			const reframedContext = getReframedMetadata(this);
+			executeAnyChildScripts(node, reframedContext);
+			if (node instanceof HTMLScriptElement) {
+				node = arguments[0] = executeScriptInReframedContext(
+					node,
+					reframedContext
+				);
+			}
+		}
+		return _Node__insertBefore.apply(this, arguments as any) as any;
+	};
+
+	const _Node__replaceChild = Node.prototype.replaceChild;
+	Node.prototype.replaceChild = function replaceChild(node, child) {
+		if (isWithinReframedDOM(this)) {
+			const reframedContext = getReframedMetadata(this);
+
+			executeAnyChildScripts(node, reframedContext);
+			if (node instanceof HTMLScriptElement && isWithinReframedDOM(node)) {
+				node = arguments[0] = executeScriptInReframedContext(
+					node,
+					reframedContext
+				);
+			}
+		}
+		return _Node__replaceChild.apply(this, arguments as any) as any;
+	};
+
+	const _Element__after = Element.prototype.after;
+	Element.prototype.after = function after(...nodes) {
+		if (isWithinReframedDOM(this)) {
+			const reframedContext = getReframedMetadata(this);
+			nodes.forEach((node, index) => {
+				if (typeof node !== "string") {
+					executeAnyChildScripts(node, reframedContext);
+					if (node instanceof HTMLScriptElement) {
+						node = arguments[index] = executeScriptInReframedContext(
+							node,
+							reframedContext
+						);
+					}
+				}
+			});
+		}
+		return _Element__after.apply(this, arguments as any) as any;
+	};
+
+	const _Element__append = Element.prototype.append;
+	Element.prototype.append = function append(...nodes) {
+		if (isWithinReframedDOM(this)) {
+			const reframedContext = getReframedMetadata(this);
+			nodes.forEach((node, index) => {
+				if (typeof node !== "string") {
+					executeAnyChildScripts(node, reframedContext);
+					if (node instanceof HTMLScriptElement) {
+						node = arguments[index] = executeScriptInReframedContext(
+							node,
+							reframedContext
+						);
+					}
+				}
+			});
+		}
+		return _Element__append.apply(this, arguments as any) as any;
+	};
+
+	const _Element__insertAdjacentElement =
+		Element.prototype.insertAdjacentElement;
+	Element.prototype.insertAdjacentElement = function insertAdjacentElement(
+		where,
+		element
+	) {
+		if (isWithinReframedDOM(this)) {
+			const reframedContext = getReframedMetadata(this);
+
+			executeAnyChildScripts(element, reframedContext);
+			if (element instanceof HTMLScriptElement) {
+				element = arguments[1] = executeScriptInReframedContext(
+					element,
+					reframedContext
+				);
+			}
+		}
+		return _Element__insertAdjacentElement.apply(this, arguments as any) as any;
+	};
+
+	const _Element__prepend = Element.prototype.prepend;
+	Element.prototype.prepend = function prepend(...nodes) {
+		if (isWithinReframedDOM(this)) {
+			const reframedContext = getReframedMetadata(this);
+			nodes.forEach((node, index) => {
+				if (typeof node !== "string") {
+					executeAnyChildScripts(node, reframedContext);
+					if (node instanceof HTMLScriptElement) {
+						node = arguments[index] = executeScriptInReframedContext(
+							node,
+							reframedContext
+						);
+					}
+				}
+			});
+		}
+		return _Element__prepend.apply(this, arguments as any) as any;
+	};
+
+	const _Element__replaceChildren = Element.prototype.replaceChildren;
+	Element.prototype.replaceChildren = function replaceChildren(...nodes) {
+		if (isWithinReframedDOM(this)) {
+			const reframedContext = getReframedMetadata(this);
+			nodes.forEach((node, index) => {
+				if (typeof node !== "string") {
+					executeAnyChildScripts(node, reframedContext);
+					if (node instanceof HTMLScriptElement) {
+						node = arguments[index] = executeScriptInReframedContext(
+							node,
+							reframedContext
+						);
+					}
+				}
+			});
+		}
+		return _Element__replaceChildren.apply(this, arguments as any) as any;
+	};
+
+	Element.prototype.replaceWith = function replaceWith(...nodes) {
+		if (isWithinReframedDOM(this)) {
+			const reframedContext = getReframedMetadata(this);
+			nodes.forEach((node, index) => {
+				if (typeof node !== "string") {
+					executeAnyChildScripts(node, reframedContext);
+					if (node instanceof HTMLScriptElement) {
+						node = arguments[index] = executeScriptInReframedContext(
+							node,
+							reframedContext
+						);
+					}
+				}
+			});
+		}
+		return _Element__replaceWith.apply(this, arguments as any) as any;
+	};
+}
+
 /**
  * Utility to convert a string to a ReadableStream.
  */
@@ -815,6 +903,7 @@ type ReframedMetadata = {
 	 * so we need to directly manage this state ourselves.
 	 */
 	iframeDocumentReadyState: DocumentReadyState;
+	iframe: HTMLIFrameElement;
 };
 
 const reframedMetadataSymbol = Symbol("reframed:metadata");
@@ -823,6 +912,13 @@ const reframedHistoryPatchSymbol = Symbol("reframed:history_patch");
 type ReframedShadowRoot = ShadowRoot & {
 	[reframedMetadataSymbol]: ReframedMetadata;
 };
+
+function isReframedShadowRoot(node: Node): node is ReframedShadowRoot {
+	return (
+		node instanceof ShadowRoot &&
+		(node as ReframedShadowRoot)[reframedMetadataSymbol] !== undefined
+	);
+}
 
 type ReframedContainer = HTMLElement & {
 	shadowRoot: ReframedShadowRoot;
@@ -833,3 +929,6 @@ declare global {
 		[reframedHistoryPatchSymbol]: number;
 	}
 }
+
+// WARNING!! This is side-effectful!
+monkeyPatchDOMInsertionMethods();


### PR DESCRIPTION
Our previous assumptions in [#42](https://github.com/web-fragments/web-fragments/pull/42) turned out to be wrong. We do indeed need to patch the main execution context's insertion methods. We now patch them to check if the node the insertion method is being called on is within a reframed container, and if so execute any potential script elements within the associated reframed context.