### PR TITLE
fix: Preserve focus and selection state when piercing

### DIFF
--- a/.changeset/beige-suits-yawn.md
+++ b/.changeset/beige-suits-yawn.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+Focus and selection state is now preserved when piercing a <fragment-host> into a <fragment-outlet>.


### PR DESCRIPTION
This PR preserves focus and selection state when we pierce an existing `<fragment-host>` into a `<fragment-outlet>`.

Selection state restoration is only a best-effort attempt due to lacking browser support and unspecified behavior in some situations. Namely, [`ShadowRoot.getSelection()`](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot) is non-standard and currently only supported in Chromium browsers. Browser behavior is also unspecified when returning selection ranges that span across shadow root boundaries. In the future, we can take advantage of [`Selection.getComposedRanges()`](https://developer.mozilla.org/en-US/docs/Web/API/Selection/getComposedRanges) to help with this once it has broader browser support.