### PR TITLE
feat: Prevent styling leakage from inherited css properties

### DIFF
--- a/.changeset/moody-lies-remain.md
+++ b/.changeset/moody-lies-remain.md
@@ -1,5 +1,5 @@
 ---
-"web-fragments": minor
+"web-fragments": patch
 ---
 
 feat: Prevent styling leakage from inherited css properties

--- a/.changeset/moody-lies-remain.md
+++ b/.changeset/moody-lies-remain.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": minor
+---
+
+feat: Prevent styling leakage from inherited css properties

--- a/e2e/pierced-react/src/index.css
+++ b/e2e/pierced-react/src/index.css
@@ -4,8 +4,11 @@
 	font-weight: 400;
 
 	color-scheme: light dark;
-	color: rgba(255, 255, 255, 0.87);
 	background-color: #242424;
+
+	/* Intentionally wacky styling defaults to test out fragment reset */
+	color: red;
+	font-size: 32px;
 
 	font-synthesis: none;
 	text-rendering: optimizeLegibility;

--- a/e2e/pierced-react/src/init.ts
+++ b/e2e/pierced-react/src/init.ts
@@ -1,0 +1,23 @@
+const styleId = "legacy-styles";
+const head = document.head || document.getElementsByTagName("head")[0];
+
+const injectLegacyStyles = () => {
+	// Comment out the following styling injection to test out fragment style reset
+	const css = `
+	  :root {
+	    color: rgba(255, 255, 255, 0.87);
+	    font-size: 16px;
+	  }
+	`;
+
+	let styleElement = document.getElementById(styleId);
+	if (styleElement) {
+		styleElement.innerText = "";
+	} else {
+		styleElement = document.createElement("style");
+		styleElement.id = styleId;
+		head.appendChild(styleElement);
+	}
+	styleElement.appendChild(document.createTextNode(css));
+};
+injectLegacyStyles();

--- a/e2e/pierced-react/src/routes/root.tsx
+++ b/e2e/pierced-react/src/routes/root.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import "../init";
 
 function App() {
 	const goTo = (url: string) => {

--- a/packages/web-fragments/src/elements/fragment-host.ts
+++ b/packages/web-fragments/src/elements/fragment-host.ts
@@ -19,6 +19,11 @@ export class FragmentHost extends HTMLElement {
 		if (!this.isInitialized) {
 			this.isInitialized = true;
 
+			// Use 'initial' as the default for all styling attributes to properly sandbox
+			// styles in shadow root. Otherwise, all elements with 'inherit' will have styles
+			// leaked from the global scope
+			this.setAttribute("style", "all: initial");
+
 			const { iframe, ready } = reframed(
 				this.shadowRoot ?? document.location.href,
 				{


### PR DESCRIPTION
Prevents style leakage by setting all css properties to `initial` by default. This prevents scenarios where `some-attribute: inherit` is causing styles from the legacy host application to leak into fragments.