### PR TITLE
Refactor History API patches and global event listener cleanup

### DIFF
--- a/.changeset/chilled-ways-swim.md
+++ b/.changeset/chilled-ways-swim.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+The `<fragment-host>` element is no longer responsible for cleaning up global `reframed` side-effects in its `disconnectedCallback`. These are now cleaned up by `reframed` itself.

--- a/.changeset/happy-goats-clap.md
+++ b/.changeset/happy-goats-clap.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+Refactored how event listeners added to the parent execution context are cleaned up. These are now removed automatically when the associated reframed iframe is unloaded.

--- a/.changeset/pretty-forks-switch.md
+++ b/.changeset/pretty-forks-switch.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+Refactored how patches to the History API are applied to the parent execution context.

--- a/.changeset/smart-rocks-tease.md
+++ b/.changeset/smart-rocks-tease.md
@@ -4,4 +4,4 @@
 
 Another attempt at fixing DOM insertion method patching.
 
-Our previous assumptions in [#42](https://github.com/web-fragments/web-fragments/pull/42) turned out to be wrong. We do indeed need to patch the main execution context's insertion methods. We now patch them to check if the node the insertion method is being called on is within a reframed container, and if so execute any potential script elements within the associated reframed context. Note that loading `reframed` is now side-effectful.
+Our previous assumptions in [#42](https://github.com/web-fragments/web-fragments/pull/42) turned out to be wrong. We do indeed need to patch the main execution context's insertion methods. We now patch them to check if the node the insertion method is being called on is within a reframed container, and if so execute any potential script elements within the associated reframed context.

--- a/packages/reframed/package.json
+++ b/packages/reframed/package.json
@@ -9,9 +9,7 @@
 	"files": [
 		"dist"
 	],
-	"sideEffects": [
-		"dist/reframed.js"
-	],
+	"sideEffects": false,
 	"license": "MIT",
 	"devDependencies": {
 		"writable-dom": "github:web-fragments/writable-dom#reframed-support",

--- a/packages/web-fragments/src/elements/fragment-host.ts
+++ b/packages/web-fragments/src/elements/fragment-host.ts
@@ -2,7 +2,7 @@ import { reframed } from "reframed";
 
 export class FragmentHost extends HTMLElement {
 	iframe: HTMLIFrameElement | undefined;
-	ready: Promise<() => void> | undefined;
+	ready: Promise<void> | undefined;
 	isInitialized = false;
 	isPortaling = false;
 
@@ -53,13 +53,6 @@ export class FragmentHost extends HTMLElement {
 		if (this.iframe && !this.isPortaling) {
 			this.iframe.remove();
 			this.iframe = undefined;
-
-			// TODO: Figure out a better way to handle restoring side effects from calling reframed()
-			// It feels wrong for the fragment-host to handle this in the disconnected callback
-			if (this.ready) {
-				const restoreMonkeyPatchSideEffects = await this.ready;
-				restoreMonkeyPatchSideEffects();
-			}
 
 			document.removeEventListener(
 				"fragment-outlet-ready",


### PR DESCRIPTION
This PR refactors how we patch the main execution context. We now make these patches in dedicated methods rather than within `monkeyPatchIframeDocument()` (which is really focused on patching the iframe's execution context, not the parent document). This initialization now happens in an idempotent way when `reframed()` is called.

It also refactors how we attach and clean up the navigation event listeners we add to the parent window. These listeners are now removed automatically when the iframe's window `unload` event fires, relieving the caller of `reframed` from the burden of needing to invoke a cleanup function.