### PR TITLE
Refactor iframe and event listener patching

### DIFF
--- a/.changeset/friendly-coins-mate.md
+++ b/.changeset/friendly-coins-mate.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+Fixed issue with History API patches causing a recursive loop

--- a/.changeset/rich-days-carry.md
+++ b/.changeset/rich-days-carry.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+Fixed incorrect iframe `document.styleSheets` patch. We were previously defining it as `document.stylesheets`.

--- a/.changeset/shaggy-birds-worry.md
+++ b/.changeset/shaggy-birds-worry.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+Refactored how addEventListener / removeEventListener are patched within the iframe environment to properly clean up listeners added to the document.

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -331,7 +331,7 @@ function monkeyPatchIFrameDocument(
 			},
 		},
 
-		stylesheets: {
+		styleSheets: {
 			get: () => {
 				return shadowRoot.styleSheets;
 			},

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -878,6 +878,7 @@ type ReframedMetadata = {
 
 const reframedInitializedSymbol = Symbol("reframed:initialized");
 const reframedMetadataSymbol = Symbol("reframed:metadata");
+const reframedReferencesSymbol = Symbol("reframed:references");
 
 type ReframedShadowRoot = ShadowRoot & {
 	[reframedMetadataSymbol]: ReframedMetadata;
@@ -888,6 +889,25 @@ function isReframedShadowRoot(node: Node): node is ReframedShadowRoot {
 		node instanceof ShadowRoot &&
 		(node as ReframedShadowRoot)[reframedMetadataSymbol] !== undefined
 	);
+}
+
+function setInternalReference<T extends object>(target: T, key: keyof T) {
+	(target as any)[reframedReferencesSymbol] ??= {};
+	(target as any)[reframedReferencesSymbol][key] = Reflect.get(target, key);
+}
+
+function getInternalReference<T extends object, K extends keyof T>(
+	target: T,
+	key: K
+): T[K] {
+	const references = (target as any)[reframedReferencesSymbol];
+	if (!references || references[key] === undefined) {
+		throw new Error(
+			`Attempted to access internal reference "${String(key)}" before it was set.`
+		);
+	}
+
+	return references[key];
 }
 
 type ReframedContainer = HTMLElement & {


### PR DESCRIPTION
This PR refactors our approach to patching the iframe in `reframed`. 

This includes:
- introducing a new mechanism for referencing some of the original unpatched properties internally where necessary
- fixing an incorrect property definition: 
```diff
- document.stylesheets
+ document.styleSheets
```
- removing internal references to `document.unreframedBody` in preparation for its deprecation and removal
- renaming `monkeyPatchIframeDocument()` to `monkeyPatchIframeEnvironment()` since it also patches properties on `iframeWindow`
- moving navigation handlers into `monkeyPatchIframeEnvironment()`
- refactoring `addEventListener()`/`removeEventListener()` patches at the `Window`/`Document` level into a single proxy at the `EventTarget` level that properly handles redirecting and cleanup.

This also fixes an issue introduced in `reframed@0.0.11` that caused a recursive loop when calling a History API method. Previously, `handleNavigate()` called `iframe.contentWindow.history.replaceState()`; however, that history instance was redefined to point at `mainWindow.history`. We now call `replaceState()` on the iframe's original `history` instance as intended.