### PR TITLE
feat: Add a header to signal when fragments are running in embedded mode

### DIFF
--- a/.changeset/yellow-tools-beam.md
+++ b/.changeset/yellow-tools-beam.md
@@ -1,0 +1,6 @@
+---
+"web-fragments": patch
+"reframed": patch
+---
+
+feat: Add a header to signal when fragments are running in embedded mode

--- a/e2e/pierced-react/fragments/remix/app/root.tsx
+++ b/e2e/pierced-react/fragments/remix/app/root.tsx
@@ -10,16 +10,13 @@ import {
 import "./tailwind.css";
 import { LoaderFunctionArgs } from "@remix-run/node";
 
-function isDocumentRequest(request: Request) {
-	return request.headers.get("sec-fetch-dest") === "document";
+function isEmbeddedMode(request: Request) {
+	return request.headers.get("x-fragment-mode") === "embedded";
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {
 	return json({
-		// If the request came from a direct navigation to the app (a document request)
-		// the app must be running standalone (e.g. in local dev) so we should serve a full html document.
-		// Otherwise, we should just serve a fragment that will be rendered inside of another host application.
-		standaloneMode: isDocumentRequest(request),
+		standaloneMode: !isEmbeddedMode(request),
 	});
 }
 

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -1,5 +1,12 @@
 import WritableDOMStream from "writable-dom";
 
+type ReframedOptions = (
+	| { container: HTMLElement }
+	| { containerTagName: string }
+) & {
+	headers?: HeadersInit;
+};
+
 /**
  *
  * @param reframedSrcOrSourceShadowRoot url of an http endpoint that will generate html stream to be reframed, or a shadowRoot containing the html to reframe
@@ -9,7 +16,7 @@ import WritableDOMStream from "writable-dom";
  */
 export function reframed(
 	reframedSrcOrSourceShadowRoot: string | ShadowRoot,
-	options: { container: HTMLElement } | { containerTagName: string } = {
+	options: ReframedOptions = {
 		containerTagName: "article",
 	}
 ): {
@@ -68,7 +75,8 @@ export function reframed(
 		reframeReady = reframeWithFetch(
 			reframedSrcOrSourceShadowRoot,
 			reframedContainer.shadowRoot as ParentNode,
-			iframe
+			iframe,
+			options
 		);
 	} else {
 		reframeReady = reframeFromTarget(reframedSrcOrSourceShadowRoot, iframe);
@@ -104,7 +112,8 @@ export function reframed(
 async function reframeWithFetch(
 	reframedSrc: string,
 	target: ParentNode,
-	iframe: HTMLIFrameElement
+	iframe: HTMLIFrameElement,
+	options: ReframedOptions
 ): Promise<void> {
 	console.debug("reframing (with fetch)!", {
 		source: reframedSrc,
@@ -112,8 +121,7 @@ async function reframeWithFetch(
 	});
 
 	const reframedHtmlResponse = await fetch(reframedSrc, {
-		// Add a header for signalling embedded mode
-		headers: { "x-fragment-mode": "embedded" },
+		headers: options.headers,
 	});
 
 	const reframedHtmlStream =

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -111,7 +111,11 @@ async function reframeWithFetch(
 		targetContainer: target,
 	});
 
-	const reframedHtmlResponse = await fetch(reframedSrc);
+	const reframedHtmlResponse = await fetch(reframedSrc, {
+		// Add a header for signalling embedded mode
+		headers: { "x-fragment-mode": "embedded" },
+	});
+
 	const reframedHtmlStream =
 		reframedHtmlResponse.status === 200
 			? reframedHtmlResponse.body!

--- a/packages/web-fragments/src/elements/fragment-host.ts
+++ b/packages/web-fragments/src/elements/fragment-host.ts
@@ -23,6 +23,7 @@ export class FragmentHost extends HTMLElement {
 				this.shadowRoot ?? document.location.href,
 				{
 					container: this,
+					headers: { "x-fragment-mode": "embedded" },
 				}
 			);
 

--- a/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
+++ b/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
@@ -84,6 +84,9 @@ export function getMiddleware(
 				//       not set to 'document'
 				fragmentReq.headers.set("sec-fetch-dest", "empty");
 
+				// Add a header for signalling embedded mode
+				fragmentReq.headers.set("x-fragment-mode", "embedded");
+
 				if (mode === "development") {
 					// brotli is not currently supported during local development (with `wrangler (pages) dev`)
 					// so we set the accept-encoding to gzip to avoid problems with it


### PR DESCRIPTION
This adds a new header to requests sent to the fragment upstream that will help us reliably identify when the fragment is being run in standalone mode vs embedded mode.