### PR TITLE
chore: [qwik] make `base` root-relative; override server URL

### DIFF
--- a/e2e/pierced-react/fragments/qwik/src/entry.ssr.tsx
+++ b/e2e/pierced-react/fragments/qwik/src/entry.ssr.tsx
@@ -20,7 +20,7 @@ import Root from "./root";
 export default function (opts: RenderToStreamOptions) {
 	return renderToStream(<Root />, {
 		...opts,
-		base: "_fragment/qwik/assets/build",
+		base: "/_fragment/qwik/assets/build",
 		manifest,
 		// Use container attributes to set attributes on the html tag.
 		containerAttributes: {
@@ -30,6 +30,7 @@ export default function (opts: RenderToStreamOptions) {
 		containerTagName: "qwik-fragment",
 		serverData: {
 			...opts.serverData,
+			url: "http://localhost:8788/qwik-page",
 		},
 		prefetchStrategy: {
 			implementation: {


### PR DESCRIPTION
This PR updates the example app's qwik fragment to:
- make the `q:base` root-relative. Assets weren't being loaded from the correct path because they were being fetched relative to the current page URL of `/qwik-page/`.
- override `serverData.url` to match that of the parent application's origin. Qwik has some same-origin checks to determine how it should handle navigations and the mismatch was causing all navigations to be hard navigations.