### PR TITLE
Set up playwright testing for reframed

### DIFF
--- a/.github/workflows/playwright-reframed.yml
+++ b/.github/workflows/playwright-reframed.yml
@@ -2,10 +2,10 @@ name: Playwright Tests
 on:
   push:
     branches: [main, master]
-    paths: ["packages/reframed/src/**"]
+    paths: ["packages/reframed/**"]
   pull_request:
     branches: [main, master]
-    paths: ["packages/reframed/src/**"]
+    paths: ["packages/reframed/**"]
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/playwright-reframed.yml
+++ b/.github/workflows/playwright-reframed.yml
@@ -1,0 +1,32 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [main, master]
+    paths: ["packages/reframed/src/**"]
+  pull_request:
+    branches: [main, master]
+    paths: ["packages/reframed/src/**"]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: "packages/reframed"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm install -g pnpm && pnpm install
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps
+      - name: Run Playwright tests
+        run: pnpm exec playwright test
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/packages/reframed/.gitignore
+++ b/packages/reframed/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/packages/reframed/package.json
+++ b/packages/reframed/package.json
@@ -12,6 +12,7 @@
 	"sideEffects": false,
 	"license": "MIT",
 	"devDependencies": {
+		"@playwright/test": "^1.46.0",
 		"writable-dom": "github:web-fragments/writable-dom#reframed-support",
 		"typescript": "^5.5.4",
 		"vite": "^5.2.0"

--- a/packages/reframed/playwright.config.ts
+++ b/packages/reframed/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+	testDir: "./tests",
+	/* Run tests in files in parallel */
+	fullyParallel: true,
+	/* Fail the build on CI if you accidentally left test.only in the source code. */
+	forbidOnly: !!process.env.CI,
+	/* Retry on CI only */
+	retries: process.env.CI ? 2 : 0,
+	/* Opt out of parallel tests on CI. */
+	workers: process.env.CI ? 1 : undefined,
+	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
+	reporter: "html",
+	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+	use: {
+		/* Base URL to use in actions like `await page.goto('/')`. */
+		baseURL: "http://test.local",
+
+		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+		trace: "on-first-retry",
+	},
+
+	globalSetup: "./tests/index.ts",
+
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+
+		{
+			name: "firefox",
+			use: { ...devices["Desktop Firefox"] },
+		},
+
+		{
+			name: "webkit",
+			use: { ...devices["Desktop Safari"] },
+		},
+	],
+});

--- a/packages/reframed/tests/basic.spec.ts
+++ b/packages/reframed/tests/basic.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from ".";
+
+test.describe("Reframing already-rendered content", () => {
+	test("reframed scripts execute in an isolated context", async ({ page }) => {
+		await page.setContent(`
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <script>
+            window.context = "main"
+          </script>
+        </head>
+        <body>
+          <div id="target">
+            <script type="inert">
+              window.context = "reframed"
+            </script>
+          </div>
+          <script>
+            Reframed.reframed(target)
+          </script>
+        </body>
+      </html>`);
+
+		const reframedContext = page.frames()[1];
+
+		expect(await page.evaluate("window.context")).toBe("main");
+		expect(await reframedContext.evaluate("window.context")).toBe("reframed");
+	});
+});
+
+test.describe("Fetch-and-reframe content", () => {
+	test("reframed scripts execute in an isolated context", async ({ page }) => {
+		page.route("**/content", async (route) => {
+			route.fulfill({
+				contentType: "text/html",
+				body: `
+          <div id="target">
+            <script>
+              window.context = "reframed"
+            </script>
+          </div>`,
+			});
+		});
+
+		await page.setContent(`
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <script>
+            window.context = "main"
+          </script>
+        </head>
+        <body>
+          <script>
+            Reframed.reframed("/content")
+          </script>
+        </body>
+      </html>`);
+
+		const reframedContext = page.frames()[1];
+
+		// FIXME: reframed currently first loads an iframe at about:blank, then sets the src.
+		// We should refactor things so that we just load the correct src initially.
+		// Once we do this, we can remove this waitForUrl()
+		await reframedContext.waitForURL("**/content");
+
+		expect(await page.evaluate("window.context")).toBe("main");
+		expect(await reframedContext.evaluate("window.context")).toBe("reframed");
+	});
+});
+
+test("reframed scripts render content into the specified container", async ({
+	page,
+}) => {
+	await page.setContent(`
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <div id="target">
+          <template shadowrootmode="open">
+            <div data-testid="container"></div>
+            <script type="inert">
+              const text = document.createElement('span')
+              text.innerText = "Hello world"
+              document.body.appendChild(text)
+            </script>
+          </template>
+        </div>
+        <script>
+          Reframed.reframed(target.shadowRoot, { container: target })
+        </script>
+      </body>
+    </html>
+	`);
+
+	await expect(page.getByText("Hello world")).toBeVisible();
+	await expect(page.getByTestId("container")).toHaveText("Hello world");
+});

--- a/packages/reframed/tests/index.ts
+++ b/packages/reframed/tests/index.ts
@@ -1,0 +1,25 @@
+import { test as setup } from "@playwright/test";
+import { build } from "vite";
+import viteConfig from "../vite.config";
+
+export * from "@playwright/test";
+
+export const test = setup.extend({
+	page: async ({ page }, use) => {
+		await page.route("/", async (route) => route.fulfill());
+		await page.goto("/");
+		await page.addScriptTag({
+			path: new URL(import.meta.resolve("../dist/reframed.umd")).pathname,
+		});
+		await use(page);
+	},
+});
+
+export default async function globalSetup() {
+	Object.assign(viteConfig.build!.lib!, {
+		name: "Reframed",
+		formats: ["umd"],
+	});
+
+	await build(viteConfig);
+}

--- a/packages/reframed/vite.config.ts
+++ b/packages/reframed/vite.config.ts
@@ -1,10 +1,9 @@
-import { resolve } from "path";
 import { defineConfig } from "vite";
 
 export default defineConfig({
 	build: {
 		lib: {
-			entry: resolve(import.meta.dirname, "index.ts"),
+			entry: new URL(import.meta.resolve("./index.ts")).pathname,
 			fileName: "reframed",
 			formats: ["es"],
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 7.15.0(eslint@8.57.0)(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.1(vite@5.3.3(@types/node@20.14.10))
+        version: 4.3.1(vite@5.3.3(@types/node@22.1.0))
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -62,7 +62,7 @@ importers:
         version: 5.5.4
       vite:
         specifier: ^5.3.1
-        version: 5.3.3(@types/node@20.14.10)
+        version: 5.3.3(@types/node@22.1.0)
       wrangler:
         specifier: ^3.63.1
         version: 3.63.1(@cloudflare/workers-types@4.20240620.0)
@@ -117,7 +117,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.10.2
-        version: 2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@20.14.10)(typescript@5.5.4)(vite@5.3.3(@types/node@20.14.10))(wrangler@3.63.1)
+        version: 2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@22.1.0)(typescript@5.5.4)(vite@5.3.3(@types/node@22.1.0))(wrangler@3.63.1)
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.3
@@ -162,10 +162,10 @@ importers:
         version: 5.5.4
       vite:
         specifier: ^5.1.0
-        version: 5.3.3(@types/node@20.14.10)
+        version: 5.3.3(@types/node@22.1.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.5.4)(vite@5.3.3(@types/node@20.14.10))
+        version: 4.3.2(typescript@5.5.4)(vite@5.3.3(@types/node@22.1.0))
 
   e2e/qwik-app:
     devDependencies:
@@ -238,7 +238,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@20.14.10)(typescript@5.5.4)(vite@5.3.3(@types/node@20.14.10))(wrangler@3.63.1)
+        version: 2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@22.1.0)(typescript@5.5.4)(vite@5.3.3(@types/node@22.1.0))(wrangler@3.63.1)
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.3
@@ -283,10 +283,10 @@ importers:
         version: 5.5.4
       vite:
         specifier: ^5.1.0
-        version: 5.3.3(@types/node@20.14.10)
+        version: 5.3.3(@types/node@22.1.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.5.4)(vite@5.3.3(@types/node@20.14.10))
+        version: 4.3.2(typescript@5.5.4)(vite@5.3.3(@types/node@22.1.0))
 
   e2e/simple-spa:
     dependencies:
@@ -306,12 +306,15 @@ importers:
 
   packages/reframed:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.46.0
+        version: 1.46.0
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
       vite:
         specifier: ^5.2.0
-        version: 5.3.3(@types/node@20.14.10)
+        version: 5.3.3(@types/node@22.1.0)
       writable-dom:
         specifier: github:web-fragments/writable-dom#reframed-support
         version: https://codeload.github.com/web-fragments/writable-dom/tar.gz/d8c96af41e71448ace4c8387391bc678dce143bd
@@ -327,7 +330,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.1(vite@5.3.3(@types/node@20.14.10))
+        version: 4.3.1(vite@5.3.3(@types/node@22.1.0))
       path-to-regexp:
         specifier: ^6.2.2
         version: 6.2.2
@@ -336,7 +339,7 @@ importers:
         version: 5.5.4
       vite:
         specifier: ^5.3.3
-        version: 5.3.3(@types/node@20.14.10)
+        version: 5.3.3(@types/node@22.1.0)
 
 packages:
 
@@ -1275,6 +1278,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.46.0':
+    resolution: {integrity: sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@remix-run/dev@2.10.2':
     resolution: {integrity: sha512-7hHC9WY65IJ5ex9Vrv9PkSg15mmYH63unxPDAR74hSfSkectMgsWtMChzdx7Kp/CzN2rttt3cxPwZnAu6PXJUw==}
     engines: {node: '>=18.0.0'}
@@ -1521,6 +1529,9 @@ packages:
 
   '@types/node@20.14.9':
     resolution: {integrity: sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==}
+
+  '@types/node@22.1.0':
+    resolution: {integrity: sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==}
 
   '@types/prop-types@15.7.12':
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
@@ -2637,6 +2648,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3831,6 +3847,16 @@ packages:
   pkg-types@1.1.3:
     resolution: {integrity: sha512-+JrgthZG6m3ckicaOB74TwQ+tBWsFl3qVQg7mN8ulwSOElJ7gBhKzj2VkCPnZ4NlF6kEquYU+RIYNVAvzd54UA==}
 
+  playwright-core@1.46.0:
+    resolution: {integrity: sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.46.0:
+    resolution: {integrity: sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
@@ -4536,6 +4562,9 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@6.13.0:
+    resolution: {integrity: sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==}
 
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
@@ -5825,7 +5854,11 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@remix-run/dev@2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@20.14.10)(typescript@5.5.4)(vite@5.3.3(@types/node@20.14.10))(wrangler@3.63.1)':
+  '@playwright/test@1.46.0':
+    dependencies:
+      playwright: 1.46.0
+
+  '@remix-run/dev@2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@22.1.0)(typescript@5.5.4)(vite@5.3.3(@types/node@22.1.0))(wrangler@3.63.1)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/generator': 7.24.7
@@ -5842,7 +5875,7 @@ snapshots:
       '@remix-run/router': 1.17.1
       '@remix-run/server-runtime': 2.10.2(typescript@5.5.4)
       '@types/mdx': 2.0.13
-      '@vanilla-extract/integration': 6.5.0(@types/node@20.14.10)
+      '@vanilla-extract/integration': 6.5.0(@types/node@22.1.0)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -5884,7 +5917,7 @@ snapshots:
     optionalDependencies:
       '@remix-run/serve': 2.10.2(typescript@5.5.4)
       typescript: 5.5.4
-      vite: 5.3.3(@types/node@20.14.10)
+      vite: 5.3.3(@types/node@22.1.0)
       wrangler: 3.63.1(@cloudflare/workers-types@4.20240620.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -6128,6 +6161,11 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@22.1.0':
+    dependencies:
+      undici-types: 6.13.0
+    optional: true
+
   '@types/prop-types@15.7.12': {}
 
   '@types/react-dom@18.3.0':
@@ -6336,7 +6374,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@vanilla-extract/integration@6.5.0(@types/node@20.14.10)':
+  '@vanilla-extract/integration@6.5.0(@types/node@22.1.0)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.7)
@@ -6349,8 +6387,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.7.1
       outdent: 0.8.0
-      vite: 5.3.3(@types/node@20.14.10)
-      vite-node: 1.6.0(@types/node@20.14.10)
+      vite: 5.3.3(@types/node@22.1.0)
+      vite-node: 1.6.0(@types/node@22.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -6364,14 +6402,14 @@ snapshots:
 
   '@vanilla-extract/private@1.0.5': {}
 
-  '@vitejs/plugin-react@4.3.1(vite@5.3.3(@types/node@20.14.10))':
+  '@vitejs/plugin-react@4.3.1(vite@5.3.3(@types/node@22.1.0))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.3.3(@types/node@20.14.10)
+      vite: 5.3.3(@types/node@22.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7631,6 +7669,9 @@ snapshots:
       minipass: 7.1.2
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -9208,6 +9249,14 @@ snapshots:
       mlly: 1.7.1
       pathe: 1.1.2
 
+  playwright-core@1.46.0: {}
+
+  playwright@1.46.0:
+    dependencies:
+      playwright-core: 1.46.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   possible-typed-array-names@1.0.0: {}
 
   postcss-discard-duplicates@5.1.0(postcss@8.4.39):
@@ -10069,6 +10118,9 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  undici-types@6.13.0:
+    optional: true
+
   undici@5.28.4:
     dependencies:
       '@fastify/busboy': 2.1.1
@@ -10252,13 +10304,13 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite-node@1.6.0(@types/node@20.14.10):
+  vite-node@1.6.0(@types/node@22.1.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.5
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.3.3(@types/node@20.14.10)
+      vite: 5.3.3(@types/node@22.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10291,6 +10343,17 @@ snapshots:
       - supports-color
       - typescript
 
+  vite-tsconfig-paths@4.3.2(typescript@5.5.4)(vite@5.3.3(@types/node@22.1.0)):
+    dependencies:
+      debug: 4.3.5
+      globrex: 0.1.2
+      tsconfck: 3.1.1(typescript@5.5.4)
+    optionalDependencies:
+      vite: 5.3.3(@types/node@22.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   vite@5.3.3(@types/node@20.14.10):
     dependencies:
       esbuild: 0.21.5
@@ -10307,6 +10370,15 @@ snapshots:
       rollup: 4.18.0
     optionalDependencies:
       '@types/node': 20.14.9
+      fsevents: 2.3.3
+
+  vite@5.3.3(@types/node@22.1.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.39
+      rollup: 4.18.0
+    optionalDependencies:
+      '@types/node': 22.1.0
       fsevents: 2.3.3
 
   wcwidth@1.0.1:


### PR DESCRIPTION
This PR sets up playwright testing for `reframed` along with a basic test suite.

It adds a playwright GitHub Actions workflow to run these tests on PRs and pushes that include changes to files within the `packages/reframed` directory.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/45d1f22f-2894-4742-88bf-ba7e0c4c888a">

