### PR TITLE
Fix double `popstate` on reframed client-side navigations

### DIFF
--- a/.changeset/gentle-timers-bow.md
+++ b/.changeset/gentle-timers-bow.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+Now including `PopStateEvent.state` when forwarding `popstate` events from the parent window to a reframed window.

--- a/.changeset/nine-melons-admire.md
+++ b/.changeset/nine-melons-admire.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+No longer dispatching an extra `popstate` event on the reframed `window` when a client-side navigation occurs in a reframed context.

--- a/packages/reframed/tests/history.spec.ts
+++ b/packages/reframed/tests/history.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from ".";
+
+test.describe("History API behavior", () => {
+	test("a reframed context ignores the broadcasted `popstate` event from the main window if it originated from a client-side navigation from that same context", async ({
+		page,
+	}) => {
+		await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.popstateCount = 0;
+              window.addEventListener('popstate', () => window.popstateCount++);
+            </script>
+          </head>
+          <body>
+            <div id="frame1">
+              <script type="inert">
+                window.popstateCount = 0;
+                window.addEventListener('popstate', () => window.popstateCount++);
+
+                // perform a client-side navigation just in this context
+                window.setTimeout(
+                  () => history.pushState(null, "", "/foo"),
+                  10
+                );
+              </script>
+            </div>
+            <div id="frame2">
+              <script type="inert">
+                window.popstateCount = 0;
+                window.addEventListener('popstate', () => window.popstateCount++);
+              </script>
+            </div>
+            <script>
+              Reframed.reframed(frame1);
+              Reframed.reframed(frame2);
+            </script>
+          </body>
+        </html>`);
+
+		await page.waitForFunction("window.popstateCount > 0");
+
+		const reframedContext1 = page.frames()[1];
+		const reframedContext2 = page.frames()[2];
+
+		// ensure a popstate event was dispatched in the contexts that didn't initiate the client-side navigation
+		expect(await page.evaluate("window.popstateCount")).toBe(1);
+		expect(await reframedContext1.evaluate("window.popstateCount")).toBe(0);
+		expect(await reframedContext2.evaluate("window.popstateCount")).toBe(1);
+
+		// ensure the navigation was correctly reflected across all execution contexts
+		expect(await page.evaluate("window.location.pathname")).toBe("/foo");
+		expect(await reframedContext1.evaluate("window.location.pathname")).toBe(
+			"/foo"
+		);
+		expect(await reframedContext2.evaluate("window.location.pathname")).toBe(
+			"/foo"
+		);
+	});
+});


### PR DESCRIPTION
This PR fixes an issue with client-side navigation initiated in a reframed context resulting in more `popstate` events being dispatched than intended.

We're currently using a synthetic `popstate` event as a way to alert execution contexts of a client-side location change via a series of patches both on the parent window's `history` methods as well as those of the `history` instances inside reframed contexts. What this PR changes is that we now bail out of dispatching that synthetic `popstate` to the reframed context which initiated the navigation.

Why use a synthetic `popstate` event? Client-side routers typically add event listeners for the `popstate` event to trigger a re-render or navigation in response to (for example) the user pressing the back button, so it's the best way we currently have of alerting the other contexts that a location change has occurred (in lieu of a more apt [`navigate`](https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event) event that we can hopefully start using in the future.)