### PR TITLE
Pierce `<fragment-host>` s only into matching `<fragment-outlet>`s

### DIFF
--- a/.changeset/quick-buttons-hear.md
+++ b/.changeset/quick-buttons-hear.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+[gateway] The `cloudflare-pages` middleware now includes the `fragment-id` on the `<fragment-host>` when server-rendering a fragment

--- a/.changeset/silly-ways-marry.md
+++ b/.changeset/silly-ways-marry.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+[elements] `<fragment-host>`s now only pierce into `<fragment-outlet>`s that have a matching `fragment-id`

--- a/.changeset/sweet-yaks-think.md
+++ b/.changeset/sweet-yaks-think.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+[elements] `A <fragment-outlet>` now gets pierced by only one `<fragment-host>`

--- a/packages/web-fragments/src/elements/fragment-host.ts
+++ b/packages/web-fragments/src/elements/fragment-host.ts
@@ -34,9 +34,7 @@ export class FragmentHost extends HTMLElement {
 			 * <fragment-outlet> will dispatch the fragment-outlet-ready event.
 			 * When that happens, move the entire host element + shadowRoot into the fragment-outlet
 			 */
-			document.addEventListener("fragment-outlet-ready", this.handlePiercing, {
-				once: true,
-			});
+			document.addEventListener("fragment-outlet-ready", this.handlePiercing);
 		}
 	}
 
@@ -58,6 +56,14 @@ export class FragmentHost extends HTMLElement {
 	}
 
 	async handlePiercing(event: Event) {
+		if (
+			event.defaultPrevented ||
+			(event.target as Element).getAttribute("fragment-id") !==
+				this.getAttribute("fragment-id")
+		) {
+			return;
+		}
+
 		// Call preventDefault() to signal the fragment-outlet that
 		// we will pierce this fragment-host into it, so it shouldn't render its own.
 		event.preventDefault();

--- a/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
+++ b/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
@@ -4,6 +4,7 @@ const fragmentHostInitialization = ({
 	content,
 	classNames,
 }: {
+	fragmentId: string;
 	content: string;
 	classNames: string;
 }) => `
@@ -149,6 +150,7 @@ export function getMiddleware(
 							//       we should look into this and support streams if possible
 							element.append(
 								fragmentHostInitialization({
+									fragmentId: matchedFragment.fragmentId,
 									// TODO: what if don't get a body (i.e. can't fetch the fragment)? we should add some error handling here
 									content: await fragmentRes.text(),
 									classNames: matchedFragment.prePiercingClassNames.join(" "),


### PR DESCRIPTION
This PR fixes a few loose ends around fragment piercing: Previously...

- the Cloudflare Pages middleware wasn't including the `fragment-id` on the `<fragment-host>` element it SSRs
- `<fragment-host>`s would indiscriminately pierce into any `<fragment-outlet>` rather than making sure it has a matching `fragment-id` first
- multiple `<fragment-host>`s could potentially attempt to pierce into a single `<fragment-outlet>`

Now, we include the `fragment-id` from the SSR response, and `<fragment-host>`s make sure they're piercing into a matching `<fragment-outlet>` and that nobody else has already done so.