### PR TITLE
Add window size patches

### DIFF
--- a/.changeset/warm-knives-talk.md
+++ b/.changeset/warm-knives-talk.md
@@ -1,0 +1,5 @@
+---
+"reframed": minor
+---
+
+Patched window size getters (`innerHeight`, etc) in the reframed context to read the parent context's equivalent. Fixes [#68](https://github.com/web-fragments/web-fragments/issues/68)

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -412,6 +412,18 @@ function monkeyPatchIFrameEnvironment(
 
 	iframeWindow.IntersectionObserver = mainWindow.IntersectionObserver;
 
+	const windowSizeProperties: (keyof Pick<
+		Window,
+		"innerHeight" | "innerWidth" | "outerHeight" | "outerWidth"
+	>)[] = ["innerHeight", "innerWidth", "outerHeight", "outerWidth"];
+	for (const windowSizeProperty of windowSizeProperties) {
+		Object.defineProperty(iframeWindow, windowSizeProperty, {
+			get: function reframedWindowSizeGetter() {
+				return mainWindow[windowSizeProperty];
+			},
+		});
+	}
+
 	const domCreateProperties: (keyof Pick<
 		Document,
 		| "createAttributeNS"


### PR DESCRIPTION
Fixes #68 

Patches [window.innerWidth](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth), `innerHeight`, `outerWidth`, and `outerHeight` to read from the parent frame, since the iframe is hidden and its dimensions are 0x0.

Alternatively, we might want the patch to read the ShadowRoot's firstElementChild's dimensions? That won't have the inner/outer distinction available.