### PR TITLE
Create custom elements using the reframed document

### DIFF
--- a/.changeset/little-walls-hear.md
+++ b/.changeset/little-walls-hear.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+Custom elements are now created by the reframed document so they use its custom element registry instead of the main window's registry. Refs [#72](https://github.com/web-fragments/web-fragments/issues/72).

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -439,8 +439,6 @@ function monkeyPatchIFrameEnvironment(
 		| "createCDATASection"
 		| "createComment"
 		| "createDocumentFragment"
-		| "createElement"
-		| "createElementNS"
 		| "createEvent"
 		| "createExpression"
 		| "createNSResolver"
@@ -454,8 +452,6 @@ function monkeyPatchIFrameEnvironment(
 		"createCDATASection",
 		"createComment",
 		"createDocumentFragment",
-		"createElement",
-		"createElementNS",
 		"createEvent",
 		"createExpression",
 		"createNSResolver",
@@ -473,6 +469,32 @@ function monkeyPatchIFrameEnvironment(
 			},
 		});
 	}
+
+	Object.defineProperties(iframeDocument, {
+		createElement: {
+			value: function createElement(
+				...[tagName]: Parameters<Document["createElement"]>
+			) {
+				return Document.prototype.createElement.apply(
+					tagName.includes("-") ? iframeDocument : mainDocument,
+					arguments as any
+				);
+			},
+		},
+		createElementNS: {
+			value: function createElementNS(
+				...[namespaceURI, tagName]: Parameters<Document["createElementNS"]>
+			) {
+				return Document.prototype.createElementNS.apply(
+					namespaceURI === "http://www.w3.org/1999/xhtml" &&
+						tagName.includes("-")
+						? iframeDocument
+						: mainDocument,
+					arguments as any
+				);
+			},
+		},
+	});
 
 	// methods to query for elements that can be retargeted into the reframedContainer
 	const domQueryProperties: (keyof Pick<


### PR DESCRIPTION
This PR allows custom elements to be created using the reframed document instead of redirecting to the main document. This enables reframed contexts to make use of their own custom element registries.

Note that this fix only affects custom elements created from within a reframed context. Any custom elements included in an embedded fragment during the initial SSR response will be parsed into the main document and will still use the top-level custom element registry. We'll need more work to support custom elements for that scenario.

Refs #72

