### PR TITLE
Patch `document` instead of `Document.prototype`

### DIFF
--- a/.changeset/brave-cooks-jog.md
+++ b/.changeset/brave-cooks-jog.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+BREAKING CHANGE: Removed `document.unreframedBody` property

--- a/.changeset/itchy-goats-cough.md
+++ b/.changeset/itchy-goats-cough.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+Fixed runtime errors when invoking `document.getElementsBy*()` methods. Fixes #60.

--- a/.changeset/itchy-goats-cough.md
+++ b/.changeset/itchy-goats-cough.md
@@ -2,4 +2,4 @@
 "reframed": patch
 ---
 
-Fixed runtime errors when invoking `document.getElementsBy*()` methods. Fixes #60.
+Fixed runtime errors when invoking `document.getElementsBy*()` methods. Fixes [#60](https://github.com/web-fragments/web-fragments/issues/60)

--- a/.changeset/pink-rings-change.md
+++ b/.changeset/pink-rings-change.md
@@ -2,4 +2,4 @@
 "reframed": patch
 ---
 
-Document patches are now applied to the `document` instance itself rather than `Document.prototype`. Fixes #73.
+Document patches are now applied to the `document` instance itself rather than `Document.prototype`. Fixes [#73](https://github.com/web-fragments/web-fragments/issues/73)

--- a/.changeset/pink-rings-change.md
+++ b/.changeset/pink-rings-change.md
@@ -1,0 +1,5 @@
+---
+"reframed": patch
+---
+
+Document patches are now applied to the `document` instance itself rather than `Document.prototype`. Fixes #73.

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -267,10 +267,30 @@ function monkeyPatchIFrameEnvironment(
 			},
 		},
 
-		// redirect getElementsByName to be a scoped reframedContainer.querySelector query
+		getElementsByClassName: {
+			value(names: string) {
+				return shadowRoot.firstElementChild?.getElementsByClassName(names);
+			},
+		},
+
 		getElementsByName: {
 			value(name: string) {
 				return shadowRoot.querySelector(`[name="${name}"]`);
+			},
+		},
+
+		getElementsByTagName: {
+			value(name: string) {
+				return shadowRoot.firstElementChild?.getElementsByTagName(name);
+			},
+		},
+
+		getElementsByTagNameNS: {
+			value(namespaceURI: string | null, name: string) {
+				return shadowRoot.firstElementChild?.getElementsByTagNameNS(
+					namespaceURI,
+					name
+				);
 			},
 		},
 

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -368,14 +368,6 @@ function monkeyPatchIFrameEnvironment(
 		},
 	} satisfies Partial<Record<keyof Document, any>>);
 
-	// TODO: we've started depending on this property in writable-dom,
-	// but we should stop doing that and remove this.
-	Object.defineProperty(iframeDocumentPrototype, "unreframedBody", {
-		get: () => {
-			return getInternalReference(iframeDocument, "body");
-		},
-	});
-
 	// iframe window patches
 	setInternalReference(iframeWindow, "history");
 


### PR DESCRIPTION
This PR moves patches of the reframed document to the `document` instance itself rather than `Document.prototype`. It also fixes the patches for `document.getElementsBy*()` to redirect to the shadow root's first element child rather than the shadow root itself (which doesn't have those methods on its interface). It also removes the `document.unreframedBody` property we're no longer depending on externally.

Fixes #60 #73