### PR TITLE
fix: fix fragment-host piercing and CSS specificity when piercing

### DIFF
--- a/.changeset/late-turtles-flow.md
+++ b/.changeset/late-turtles-flow.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+Add fragment-id attribute to fragment-host in order to properly pierce into the fragment-outlet

--- a/.changeset/silver-fans-draw.md
+++ b/.changeset/silver-fans-draw.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+Insert CSS rule in reverse order when constructing a stylesheet during piercing in order to retain CSS specificity

--- a/packages/web-fragments/src/elements/fragment-host.ts
+++ b/packages/web-fragments/src/elements/fragment-host.ts
@@ -106,7 +106,12 @@ export class FragmentHost extends HTMLElement {
 				this.shadowRoot.styleSheets,
 				(sheet) => {
 					const clone = new CSSStyleSheet();
-					[...sheet.cssRules].forEach((rule) => clone.insertRule(rule.cssText));
+
+					// CSSStyleSheet.insertRule() prepends CSS rules to the top of the stylesheet by default.
+					// We need to set the index to sheet.cssRules.length in order to append the rule and maintain specificity.
+					[...sheet.cssRules].forEach((rule) =>
+						clone.insertRule(rule.cssText, clone.cssRules.length)
+					);
 					return clone;
 				}
 			);

--- a/packages/web-fragments/src/elements/fragment-outlet.ts
+++ b/packages/web-fragments/src/elements/fragment-outlet.ts
@@ -18,8 +18,11 @@ export class FragmentOutlet extends HTMLElement {
 			new Event("fragment-outlet-ready", { bubbles: true, cancelable: true })
 		);
 
+		// There is no <fragment-host> element mounted that needs to pierce into <fragment-outlet>.
+		// Instantiate a <fragment-host> element that can fetch the fragment via reframed
 		if (didNotPierce) {
 			const fragmentHost = document.createElement("fragment-host");
+			fragmentHost.setAttribute("fragment-id", fragmentId);
 			this.appendChild(fragmentHost);
 		}
 	}

--- a/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
+++ b/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
@@ -1,6 +1,7 @@
 import type { FragmentGateway } from "../../fragment-gateway";
 
 const fragmentHostInitialization = ({
+	fragmentId,
 	content,
 	classNames,
 }: {
@@ -8,7 +9,7 @@ const fragmentHostInitialization = ({
 	content: string;
 	classNames: string;
 }) => `
-<fragment-host class="${classNames}" data-piercing="true">
+<fragment-host class="${classNames}" fragment-id="${fragmentId}" data-piercing="true">
   <template shadowrootmode="open">${content}</template>
 </fragment-host>`;
 


### PR DESCRIPTION
- fix fragment-host not piercing into fragment-outlet
- fix CSS stylesheets not inserting rules in correct order