### PR TITLE
Add `additionalHeaders` option to Cloudflare Pages middleware

### DIFF
--- a/.changeset/popular-paws-cheer.md
+++ b/.changeset/popular-paws-cheer.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": minor
+---
+
+[gateway] BREAKING CHANGE: Cloudflare Pages `getMiddleware()` function's second parameter is now an `options` object rather than a single `mode: string`.

--- a/.changeset/proud-glasses-hear.md
+++ b/.changeset/proud-glasses-hear.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": minor
+---
+
+[gateway] Cloudflare Pages `getMiddleware()` now accepts an `additionalHeaders` option that allows you to include additional headers in the request to the upstream fragment.

--- a/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
+++ b/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
@@ -13,10 +13,17 @@ const fragmentHostInitialization = ({
   <template shadowrootmode="open">${content}</template>
 </fragment-host>`;
 
+export type FragmentMiddlewareOptions = {
+	additionalHeaders?: HeadersInit;
+	mode?: "production" | "development";
+};
+
 export function getMiddleware(
 	gateway: FragmentGateway,
-	mode: "production" | "development" = "development"
+	options: FragmentMiddlewareOptions = {}
 ): PagesFunction<unknown> {
+	const { additionalHeaders = {}, mode = "development" } = options;
+
 	return async ({ request, next }) => {
 		/**
 		 * This early return makes it so that all http requests
@@ -81,6 +88,12 @@ export function getMiddleware(
 				});
 
 				const fragmentReq = new Request(upstreamUrl, request);
+
+				// attach additionalHeaders to fragment request
+				for (const [name, value] of new Headers(additionalHeaders).entries()) {
+					fragmentReq.headers.set(name, value);
+				}
+
 				// Note: we don't want to forward the sec-fetch-dest since we usually need
 				//       custom logic so that we avoid returning full htmls if the header is
 				//       not set to 'document'


### PR DESCRIPTION
This PR introduces an `additionalHeaders` option to the Cloudflare Pages middleware to allow including additional headers when forwarding requests to fragment upstreams.

This will enable use-cases such as resolving a user's locale preference within the Fragment Gateway and passing that along to the upstream fragment application via an `Accept-Language` header.