### PR TITLE
Refactor Cloudflare Pages middleware

### DIFF
--- a/.changeset/sweet-goats-work.md
+++ b/.changeset/sweet-goats-work.md
@@ -1,0 +1,5 @@
+---
+"web-fragments": patch
+---
+
+Fixed issue with `additionalHeaders` not being included on soft-navigations to a fragment

--- a/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
+++ b/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
@@ -1,4 +1,4 @@
-import type { FragmentGateway } from "../../fragment-gateway";
+import type { FragmentConfig, FragmentGateway } from "../../fragment-gateway";
 
 const fragmentHostInitialization = ({
 	fragmentId,
@@ -25,179 +25,181 @@ export function getMiddleware(
 	const { additionalHeaders = {}, mode = "development" } = options;
 
 	return async ({ request, next }) => {
-		/**
-		 * This early return makes it so that all http requests
-		 * from an iframe return an empty html response.
-		 *
-		 * This is done to enable setting iframe.src in reframed,
-		 * so that window.location (which is unpatchable and can't
-		 * be modified without triggering an undesirable iframe
-		 * reload) in the reframed context has the correct url.
-		 */
-		if (request.headers.get("sec-fetch-dest") === "iframe") {
-			const matchedFragment = gateway.matchRequestToFragment(request);
-			if (matchedFragment) {
+		const matchedFragment = gateway.matchRequestToFragment(request);
+
+		if (matchedFragment) {
+			// If this request was initiated by an iframe (via reframed),
+			// return a stub document.
+			//
+			// Reframed has to set the iframe's `src` to the fragment URL to have
+			// its `document.location` reflect the correct value
+			// (and also avoid same-origin policy restrictions).
+			// However, we don't want the iframe's document to actually contain the
+			// fragment's content; we're only using it as an isolated execution context.
+			// Returning a stub document here is our workaround to that problem.
+			if (request.headers.get("sec-fetch-dest") === "iframe") {
 				return new Response("<!doctype html><title>");
 			}
-		}
 
-		// If this is a document request, we should bail and
-		// let the dash static asset handler return the dash document
-		if (request.headers.get("sec-fetch-dest") !== "document") {
-			// Otherwise, we should try to match the incoming request path against
-			// any of the registered fragment route patterns, and if we get a match
-			// return the fetch from the fragment's upstream.
-			const matchedFragment = gateway.matchRequestToFragment(request);
-			if (matchedFragment) {
-				const requestUrl = new URL(request.url);
-				const upstreamUrl = new URL(
-					`${requestUrl.pathname}${requestUrl.search}`,
-					matchedFragment.upstream
-				);
+			const fragmentResponse = fetchFragment(request, matchedFragment);
 
-				return fetch(upstreamUrl, request);
+			// If this is a document request, we need to fetch the host application
+			// and if we get a successful HTML response, we need to embed the fragment inside it.
+			if (request.headers.get("sec-fetch-dest") === "document") {
+				const hostResponse = await next();
+				const isHTMLResponse = !!hostResponse.headers
+					.get("content-type")
+					?.startsWith("text/html");
+
+				if (hostResponse.ok && isHTMLResponse) {
+					return fragmentResponse
+						.then(rejectErrorResponses)
+						.catch(handleFetchErrors(request, matchedFragment))
+						.then(prepareFragmentForReframing)
+						.then(embedFragmentIntoHost(hostResponse, matchedFragment))
+						.then(attachForwardedHeaders(fragmentResponse, matchedFragment))
+						.catch(renderErrorResponse);
+				}
 			}
+
+			// Otherwise, just return the fragment response.
+			return fragmentResponse;
+		} else {
+			return next();
 		}
-
-		const hostResponse = await next();
-		const isHTMLResponse = !!hostResponse.headers
-			.get("content-type")
-			?.startsWith("text/html");
-
-		if (isHTMLResponse) {
-			const matchedFragment = gateway.matchRequestToFragment(request);
-			if (matchedFragment) {
-				const {
-					fragmentId,
-					upstream,
-					forwardFragmentHeaders,
-					prePiercingClassNames,
-					onSsrFetchError,
-				} = matchedFragment;
-				const requestUrl = new URL(request.url);
-				const upstreamUrl = new URL(
-					`${requestUrl.pathname}${requestUrl.search}`,
-					upstream
-				);
-
-				// TODO: this logic should not be here but in the reframed package (and imported and used here)
-				//       since there's a coordination need between the gateway and what happens in the browser
-				//       and if the code is split things can easily get out of sync
-				const scriptRewriter = new HTMLRewriter().on("script", {
-					element(element) {
-						const scriptType = element.getAttribute("type");
-						if (scriptType) {
-							element.setAttribute("data-script-type", scriptType);
-						}
-						element.setAttribute("type", "inert");
-					},
-				});
-
-				const fragmentReq = new Request(upstreamUrl, request);
-
-				// attach additionalHeaders to fragment request
-				for (const [name, value] of new Headers(additionalHeaders).entries()) {
-					fragmentReq.headers.set(name, value);
-				}
-
-				// Note: we don't want to forward the sec-fetch-dest since we usually need
-				//       custom logic so that we avoid returning full htmls if the header is
-				//       not set to 'document'
-				fragmentReq.headers.set("sec-fetch-dest", "empty");
-
-				// Add a header for signalling embedded mode
-				fragmentReq.headers.set("x-fragment-mode", "embedded");
-
-				if (mode === "development") {
-					// brotli is not currently supported during local development (with `wrangler (pages) dev`)
-					// so we set the accept-encoding to gzip to avoid problems with it
-					fragmentReq.headers.set("Accept-Encoding", "gzip");
-				}
-
-				let embeddedFragmentResponse: Response = new Response();
-				let fragmentFailedResOrError: Response | unknown | null = null;
-				try {
-					const fragmentResponse = await fetch(fragmentReq);
-					if (
-						fragmentResponse.status >= 400 &&
-						fragmentResponse.status <= 599
-					) {
-						fragmentFailedResOrError = fragmentResponse;
-					} else {
-						embeddedFragmentResponse =
-							scriptRewriter.transform(fragmentResponse);
-					}
-				} catch (e) {
-					fragmentFailedResOrError = e;
-				}
-
-				/**
-				 * If the fetch for the fragment fails, we need to be able to handle that response gracefully.
-				 * Each fragment can define it's own error handling callback which returns a Response to be then embedded
-				 * in the initial SSR response coming from the downstream route handler.
-				 *
-				 * For scenarios where you want to completely overwrite the response on error,
-				 * return an object from the callback with property {overwriteResponse: true}
-				 */
-				if (fragmentFailedResOrError) {
-					if (onSsrFetchError) {
-						const { response, overrideResponse } = await onSsrFetchError(
-							fragmentReq,
-							fragmentFailedResOrError
-						);
-
-						if (overrideResponse) {
-							return response;
-						}
-
-						embeddedFragmentResponse = response;
-					} else {
-						embeddedFragmentResponse = new Response(
-							mode === "development"
-								? `<p>Fetching fragment upstream failed: ${upstream}</p>`
-								: "<p>There was a problem fulfilling your request.</p>",
-							{ headers: [["content-type", "text/html"]] }
-						);
-					}
-				}
-
-				const rewriter = new HTMLRewriter()
-					.on("head", {
-						element(element) {
-							element.append(gateway.prePiercingStyles, { html: true });
-						},
-					})
-					.on("body", {
-						async element(element) {
-							// TODO: the HTMLRewriter API doesn't allow us to pass a stream, or maybe it does?
-							//       we should look into this and support streams if possible
-							element.append(
-								fragmentHostInitialization({
-									fragmentId,
-									// TODO: what if don't get a body (i.e. can't fetch the fragment)? we should add some error handling here
-									content: await embeddedFragmentResponse.text(),
-									classNames: prePiercingClassNames.join(" "),
-								}),
-								{ html: true }
-							);
-						},
-					});
-
-				const gatewayResponse = rewriter.transform(hostResponse);
-
-				if (forwardFragmentHeaders?.length) {
-					forwardFragmentHeaders.forEach((header) => {
-						gatewayResponse.headers.append(
-							header,
-							embeddedFragmentResponse.headers.get(header) || ""
-						);
-					});
-				}
-
-				return gatewayResponse;
-			}
-		}
-
-		return hostResponse;
 	};
+
+	async function fetchFragment(
+		request: Request,
+		fragmentConfig: FragmentConfig
+	) {
+		const { upstream } = fragmentConfig;
+		const requestUrl = new URL(request.url);
+		const upstreamUrl = new URL(
+			`${requestUrl.pathname}${requestUrl.search}`,
+			upstream
+		);
+
+		const fragmentReq = new Request(upstreamUrl, request);
+
+		// attach additionalHeaders to fragment request
+		for (const [name, value] of new Headers(additionalHeaders).entries()) {
+			fragmentReq.headers.set(name, value);
+		}
+
+		// Note: we don't want to forward the sec-fetch-dest since we usually need
+		//       custom logic so that we avoid returning full htmls if the header is
+		//       not set to 'document'
+		fragmentReq.headers.set("sec-fetch-dest", "empty");
+
+		// Add a header for signalling embedded mode
+		fragmentReq.headers.set("x-fragment-mode", "embedded");
+
+		if (mode === "development") {
+			// brotli is not currently supported during local development (with `wrangler (pages) dev`)
+			// so we set the accept-encoding to gzip to avoid problems with it
+			fragmentReq.headers.set("Accept-Encoding", "gzip");
+		}
+
+		return fetch(fragmentReq);
+	}
+
+	function rejectErrorResponses(response: Response) {
+		if (response.ok) return response;
+		throw response;
+	}
+
+	function handleFetchErrors(
+		fragmentRequest: Request,
+		fragmentConfig: FragmentConfig
+	) {
+		return async (fragmentResponseOrError: unknown) => {
+			const {
+				upstream,
+				onSsrFetchError = () => ({
+					response: new Response(
+						mode === "development"
+							? `<p>Fetching fragment upstream failed: ${upstream}</p>`
+							: "<p>There was a problem fulfilling your request.</p>",
+						{ headers: [["content-type", "text/html"]] }
+					),
+					overrideResponse: false,
+				}),
+			} = fragmentConfig;
+
+			const { response, overrideResponse } = await onSsrFetchError(
+				fragmentRequest,
+				fragmentResponseOrError
+			);
+
+			if (overrideResponse) throw response;
+			return response;
+		};
+	}
+
+	function renderErrorResponse(err: unknown) {
+		if (err instanceof Response) return err;
+		throw err;
+	}
+
+	// When embedding an SSRed fragment, we need to make
+	// any included scripts inert so they only get executed by Reframed.
+	function prepareFragmentForReframing(fragmentResponse: Response) {
+		return new HTMLRewriter()
+			.on("script", {
+				element(element) {
+					const scriptType = element.getAttribute("type");
+					if (scriptType) {
+						element.setAttribute("data-script-type", scriptType);
+					}
+					element.setAttribute("type", "inert");
+				},
+			})
+			.transform(fragmentResponse);
+	}
+
+	function embedFragmentIntoHost(
+		hostResponse: Response,
+		fragmentConfig: FragmentConfig
+	) {
+		return (fragmentResponse: Response) => {
+			const { fragmentId, prePiercingClassNames } = fragmentConfig;
+
+			return new HTMLRewriter()
+				.on("head", {
+					element(element) {
+						element.append(gateway.prePiercingStyles, { html: true });
+					},
+				})
+				.on("body", {
+					async element(element) {
+						element.append(
+							fragmentHostInitialization({
+								fragmentId,
+								content: await fragmentResponse.text(),
+								classNames: prePiercingClassNames.join(" "),
+							}),
+							{ html: true }
+						);
+					},
+				})
+				.transform(hostResponse);
+		};
+	}
+
+	function attachForwardedHeaders(
+		fragmentResponse: Promise<Response>,
+		fragmentConfig: FragmentConfig
+	) {
+		return async (response: Response) => {
+			const fragmentHeaders = (await fragmentResponse).headers;
+			const { forwardFragmentHeaders = [] } = fragmentConfig;
+
+			for (const header of forwardFragmentHeaders) {
+				response.headers.append(header, fragmentHeaders.get(header) || "");
+			}
+
+			return response;
+		};
+	}
 }


### PR DESCRIPTION
This PR refactors the Cloudflare Pages fragment gateway middleware to consolidate the fetching logic and be easier to follow.

In some respects, this is also a followup to https://github.com/web-fragments/web-fragments/pull/87 to fix an issue where `additionalHeaders` weren't being included for non-document requests. Core fragment-fetching logic is now encapsulated in a `fetchFragment` function that's used in all scenarios when making upstream fetches to a fragment.