### PR TITLE
Embed fragment HTML via ReadableStream

### DIFF
--- a/.changeset/plenty-dragons-repeat.md
+++ b/.changeset/plenty-dragons-repeat.md
@@ -1,0 +1,5 @@
+---
+'web-fragments': patch
+---
+
+Cloudflare Pages fragment gateway middleware now streams fragment content from upstream

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist-ssr
 *.local
 
 .github
-.changeset
 
 # Editor directories and files
 .vscode/*

--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -53,7 +53,7 @@
 		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
-		"@cloudflare/workers-types": "^4.20240620.0"
+		"@cloudflare/workers-types": "^4.20250109.0"
 	},
 	"peerDependenciesMeta": {
 		"@cloudflare/workers-types": {

--- a/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
+++ b/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
@@ -1,4 +1,5 @@
 import type { FragmentConfig, FragmentGateway } from '../../fragment-gateway';
+import { asReadableStream } from '../../stream-utilities';
 
 const fragmentHostInitialization = ({
 	fragmentId,
@@ -6,9 +7,9 @@ const fragmentHostInitialization = ({
 	classNames,
 }: {
 	fragmentId: string;
-	content: string;
+	content: string | ReadableStream;
 	classNames: string;
-}) => `
+}) => asReadableStream`
 <fragment-host class="${classNames}" fragment-id="${fragmentId}" data-piercing="true">
   <template shadowrootmode="open">${content}</template>
 </fragment-host>`;
@@ -159,7 +160,7 @@ export function getMiddleware(
 						element.append(
 							fragmentHostInitialization({
 								fragmentId,
-								content: await fragmentResponse.text(),
+								content: fragmentResponse.body,
 								classNames: prePiercingClassNames.join(' '),
 							}),
 							{ html: true },

--- a/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
+++ b/packages/web-fragments/src/gateway/middlewares/cloudflare-pages/index.ts
@@ -7,11 +7,11 @@ const fragmentHostInitialization = ({
 	classNames,
 }: {
 	fragmentId: string;
-	content: string | ReadableStream;
+	content: string | ReadableStream | null;
 	classNames: string;
 }) => asReadableStream`
 <fragment-host class="${classNames}" fragment-id="${fragmentId}" data-piercing="true">
-  <template shadowrootmode="open">${content}</template>
+  <template shadowrootmode="open">${content ?? ''}</template>
 </fragment-host>`;
 
 export type FragmentMiddlewareOptions = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,7 +237,7 @@ importers:
         version: 4.3.2(typescript@5.5.4)(vite@5.3.3(@types/node@20.14.10)(lightningcss@1.27.0)(terser@5.34.1))
       wrangler:
         specifier: ^3.63.1
-        version: 3.63.1(@cloudflare/workers-types@4.20241205.0)
+        version: 3.63.1(@cloudflare/workers-types@4.20250109.0)
 
   e2e/pierced-react/fragments/remix:
     dependencies:
@@ -262,7 +262,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.10.2
-        version: 2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1)(typescript@5.5.4)(vite@5.3.3(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1))(wrangler@3.94.0(@cloudflare/workers-types@4.20241205.0))
+        version: 2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1)(typescript@5.5.4)(vite@5.3.3(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1))(wrangler@3.94.0(@cloudflare/workers-types@4.20250109.0))
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.3
@@ -383,7 +383,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1)(typescript@5.5.4)(vite@5.3.3(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1))(wrangler@3.94.0(@cloudflare/workers-types@4.20241205.0))
+        version: 2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1)(typescript@5.5.4)(vite@5.3.3(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1))(wrangler@3.94.0(@cloudflare/workers-types@4.20250109.0))
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.3
@@ -467,8 +467,8 @@ importers:
   packages/web-fragments:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20240620.0
-        version: 4.20240620.0
+        specifier: ^4.20250109.0
+        version: 4.20250109.0
       reframed:
         specifier: workspace:*
         version: link:../reframed
@@ -1039,6 +1039,9 @@ packages:
 
   '@cloudflare/workers-types@4.20241205.0':
     resolution: {integrity: sha512-pj1VKRHT/ScQbHOIMFODZaNAlJHQHdBSZXNIdr9ebJzwBff9Qz8VdqhbhggV7f+aUEh8WSbrsPIo4a+WtgjUvw==}
+
+  '@cloudflare/workers-types@4.20250109.0':
+    resolution: {integrity: sha512-Y1zgSaEOOevl9ORpzgMcm4j535p3nK2lrblHHvYM2yxR50SBKGh+wvkRFAIxWRfjUGZEU+Fp6923EGioDBbobA==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -6686,9 +6689,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.5.3:
-    resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
-
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
@@ -8172,6 +8172,8 @@ snapshots:
 
   '@cloudflare/workers-types@4.20241205.0': {}
 
+  '@cloudflare/workers-types@4.20250109.0': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -8835,7 +8837,7 @@ snapshots:
     dependencies:
       playwright: 1.46.0
 
-  '@remix-run/dev@2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1)(typescript@5.5.4)(vite@5.3.3(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1))(wrangler@3.94.0(@cloudflare/workers-types@4.20241205.0))':
+  '@remix-run/dev@2.10.2(@remix-run/react@2.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4))(@remix-run/serve@2.10.2(typescript@5.5.4))(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1)(typescript@5.5.4)(vite@5.3.3(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1))(wrangler@3.94.0(@cloudflare/workers-types@4.20250109.0))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/generator': 7.24.7
@@ -8895,7 +8897,7 @@ snapshots:
       '@remix-run/serve': 2.10.2(typescript@5.5.4)
       typescript: 5.5.4
       vite: 5.3.3(@types/node@22.5.0)(lightningcss@1.27.0)(terser@5.34.1)
-      wrangler: 3.94.0(@cloudflare/workers-types@4.20241205.0)
+      wrangler: 3.94.0(@cloudflare/workers-types@4.20250109.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11238,7 +11240,7 @@ snapshots:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
@@ -11250,7 +11252,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11286,7 +11288,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.14.0
       is-glob: 4.0.3
@@ -13575,7 +13577,7 @@ snapshots:
       acorn: 8.12.1
       pathe: 1.1.2
       pkg-types: 1.1.3
-      ufo: 1.5.3
+      ufo: 1.5.4
 
   mlly@1.7.3:
     dependencies:
@@ -15260,8 +15262,6 @@ snapshots:
 
   typescript@5.7.2: {}
 
-  ufo@1.5.3: {}
-
   ufo@1.5.4: {}
 
   uhyphen@0.2.0: {}
@@ -15292,7 +15292,7 @@ snapshots:
       mime: 3.0.0
       node-fetch-native: 1.6.4
       pathe: 1.1.2
-      ufo: 1.5.3
+      ufo: 1.5.4
 
   unenv-nightly@2.0.0-20241204-140205-a5d5190:
     dependencies:
@@ -15847,7 +15847,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  wrangler@3.63.1(@cloudflare/workers-types@4.20241205.0):
+  wrangler@3.63.1(@cloudflare/workers-types@4.20250109.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
@@ -15866,7 +15866,7 @@ snapshots:
       unenv: unenv-nightly@1.10.0-1717606461.a117952
       xxhash-wasm: 1.0.2
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20241205.0
+      '@cloudflare/workers-types': 4.20250109.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil
@@ -15900,6 +15900,35 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  wrangler@3.94.0(@cloudflare/workers-types@4.20250109.0):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.3.4
+      '@cloudflare/workers-shared': 0.11.0
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      chokidar: 4.0.1
+      date-fns: 4.1.0
+      esbuild: 0.17.19
+      itty-time: 1.0.6
+      miniflare: 3.20241205.0
+      nanoid: 3.3.7
+      path-to-regexp: 6.3.0
+      resolve: 1.22.8
+      selfsigned: 2.4.1
+      source-map: 0.6.1
+      unenv: unenv-nightly@2.0.0-20241204-140205-a5d5190
+      workerd: 1.20241205.0
+      xxhash-wasm: 1.0.2
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20250109.0
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
This PR utilizes HTMLRewriter's support for interpolating content from a  ReadableStream into HTML transformations. Previously we were limited to injecting content from the upstream only as a string, meaning we had to await the response and block TTFB. Instead, we now pass along the response body stream and it get consumed directly as part of the HTML transformation.

This PR adds a new `asReadableStream` tagged template helper to produce a `ReadableStream` from interpolated strings and/or other `ReadableStream`s in a nice ergonomic way. e.g.
```tsx
const fragmentTemplateStream = asReadableStream`
  <template>${upstreamResponse.body}</template>
`
```