### PR TITLE
Fix changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://unpkg.com/@changesets/config@3.0.2/schema.json",
-	"changelog": "@changesets/cli/changelog",
+	"changelog": ["@changesets/changelog-github", { "repo": "web-fragments/web-fragments" }],
 	"commit": false,
 	"fixed": [],
 	"linked": [],

--- a/.changeset/fifty-owls-exist.md
+++ b/.changeset/fifty-owls-exist.md
@@ -1,0 +1,5 @@
+---
+'web-fragments': minor
+---
+
+[gateway] BREAKING CHANGE: Fragment registration `FragmentConfig` property `upstream` renamed to `endpoint`.

--- a/packages/web-fragments/CHANGELOG.md
+++ b/packages/web-fragments/CHANGELOG.md
@@ -1,11 +1,5 @@
 # web-fragments
 
-## 0.1.2
-
-# Minor Changes
-
-- b449ed4: [gateway] BREAKING CHANGE: Fragment registration `FrgamentConfig` property `upstream` renamed to `endpoint`.
-
 ## 0.1.1
 
 ### Patch Changes


### PR DESCRIPTION
It looks like the CHANGELOG for the `web-fragments` package was manually edited instead of being updated via changesets during a release. This PR removes the manual entry and adds a corresponding changeset for the change.

This PR also updates the changelog generator to [`@changesets/changelog-github`](https://github.com/changesets/changesets/tree/main/packages/changelog-github) for nicer formatting, including commit/PR links and contributor mentions.