### PR TITLE
Make deprecated property `upstream` optional

### DIFF
--- a/.changeset/gorgeous-olives-wink.md
+++ b/.changeset/gorgeous-olives-wink.md
@@ -1,0 +1,5 @@
+---
+'web-fragments': patch
+---
+
+[gateway] TypeScript no longer throws an error if the deprecated `upstream` property is missing.

--- a/packages/web-fragments/src/gateway/fragment-gateway.ts
+++ b/packages/web-fragments/src/gateway/fragment-gateway.ts
@@ -35,7 +35,7 @@ export interface FragmentConfig {
 	/**
 	 * @deprecated use `endpoint` instead
 	 */
-	upstream: string;
+	upstream?: string;
 	/**
 	 * An optional list of fragment response headers to forward to the gateway response.
 	 */


### PR DESCRIPTION
The property `upstream` was renamed to `endpoint` in #94 and retroactively marked as `@deprecated`, but it's still a required property of `FragmentConfig` so TypeScript gets mad if it's not provided. This PR makes this property optional.