### PR TITLE
fix: reflect navigation events like location.reload() from iframe to main window

### DIFF
--- a/.changeset/thin-schools-move.md
+++ b/.changeset/thin-schools-move.md
@@ -1,0 +1,5 @@
+---
+'reframed': patch
+---
+
+fix: reflect intended navigation events like window.location.reload() from iframe to main window

--- a/e2e/pierced-react/fragments/remix/app/routes/remix-page.tsx
+++ b/e2e/pierced-react/fragments/remix/app/routes/remix-page.tsx
@@ -52,6 +52,22 @@ export default function Index() {
 							Go to /remix-page/details 👉
 						</Link>
 					</div>
+					<button
+						style={{
+							display: 'block',
+							padding: '0.5rem',
+							margin: '1rem 0',
+							backgroundColor: '#333',
+							borderRadius: '5px',
+							fontSize: '1rem',
+							color: '#fff',
+						}}
+						onClick={() => {
+							window.location.href = '/';
+						}}
+					>
+						Go to /
+					</button>
 					<p>Current Route: /remix-page</p>
 					<div className="counter">
 						<button


### PR DESCRIPTION
# Overview
When signaling an intent to perform a navigation event like `window.location.reload()` or by setting `window.location.href`, the fragment is incorrectly reloaded and the navigation event is not reflected on the main window. This is difficult to solve because `window.location` is a non-configurable and non-writable object for security purposes.

Until the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) has better browser support, we need to find a way to infer that a navigation event has occurred in order to intercept it. As a workaround, after the iframe environment is monkeypatched, assume that all subsequent iframe load events are triggered by an intent to reload the fragment or hard navigate to a different route. Reflect that "intent to navigate" by setting the `window.location.href` of the main window to match the `iframe.contentWindow`

## Related Issues
https://github.com/web-fragments/web-fragments/issues/111