### PR TITLE
Feat: Add Error Event to Fragment Host and Outlet

### DIFF
--- a/docs/src/pages/documentation/elements.md
+++ b/docs/src/pages/documentation/elements.md
@@ -33,7 +33,7 @@ In the context of Web Fragments, a `fragment outlet` is a custom element, repons
 
 ## Fragment Host Client Side
 
-When the application runs and the <fragment-outlet> is parsed it dispatches the 'fragment-outlet-ready' event is trigeered and, when not in place a `fragment host` custom element is mounted and nested inside of the `fragment outlet`, taking its `fragment-id`.
+When the application runs and the <fragment-outlet> is parsed it dispatches the 'fragment-outlet-ready' event is triggered and, when not in place a `fragment host` custom element is mounted and nested inside of the `fragment outlet`, taking its `fragment-id`.
 
 From that moment on, the following `reframed` operations take place:
 
@@ -46,6 +46,11 @@ From that moment on, the following `reframed` operations take place:
 ![web fragments middleware](../../assets/images/wf-middleware.drawio.png)
 
 At the same time, an `iframe` will be created in the DOM, to encapsulate all scripts from the remotely fetched application as a fragment.
+
+## Error Handling
+
+The `fragment-outlet` element will dispatch an `fragment-outlet-error` event when the fragment fails to load.
+The `fragment-host` element will dispatch an `fragment-host-error` event will fire when there is any type of error during fetching the reframed source.
 
 ## Middleware
 

--- a/e2e/pierced-react/functions/_middleware.ts
+++ b/e2e/pierced-react/functions/_middleware.ts
@@ -38,6 +38,23 @@ const getGatewayMiddleware: ((devMode: boolean) => PagesFunction) & {
 		},
 	});
 
+	// Only used to demonstrate the ability to trigger error event while fetching the fragment
+	gateway.registerFragment({
+		fragmentId: 'remix-error',
+		prePiercingClassNames: ['remix'],
+		routePatterns: ['/remix-error-page/:_*', '/_fragment/remix-error/:_*'],
+		// Note: This fragment doesn't exist, and will throw a network error while fetching
+		endpoint: 'http://localhost:3001',
+		onSsrFetchError: () => {
+			return {
+				response: new Response(
+					"<p id='remix-fragment-not-found'><style>#remix-fragment-not-found { color: red; font-size: 2rem; }</style>Remix fragment not found</p>",
+					{ headers: [['content-type', 'text/html']] },
+				),
+			};
+		},
+	});
+
 	gateway.registerFragment({
 		fragmentId: 'qwik',
 		prePiercingClassNames: ['qwik'],

--- a/e2e/pierced-react/src/main.tsx
+++ b/e2e/pierced-react/src/main.tsx
@@ -20,6 +20,10 @@ const router = createBrowserRouter([
 		path: '/remix-page/*',
 		element: <RemixPage />,
 	},
+	{
+		path: '/remix-error-page/*',
+		element: <RemixPage />,
+	},
 ]);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/e2e/pierced-react/src/routes/remix.tsx
+++ b/e2e/pierced-react/src/routes/remix.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import reactLogo from '../assets/react.svg';
 import remixLogo from '../assets/remix.svg';
 import '../App.css';
@@ -10,6 +10,19 @@ function App() {
 	const toggleShowHost = () => {
 		setShowHost(!showHost);
 	};
+	const fragmentOutletRef = useRef<HTMLElement>(null);
+	useEffect(() => {
+		const handleError = (e: Event) => {
+			const { error } = e as ErrorEvent;
+			console.log('Error Detected, Handling from client host', error);
+			fragmentOutletRef.current?.setHTMLUnsafe(`<h1>Error: ${error.message}</h1>`);
+		};
+
+		fragmentOutletRef.current?.addEventListener('fragment-host-error', handleError);
+		return () => {
+			fragmentOutletRef.current?.removeEventListener('fragment-host-error', handleError);
+		};
+	}, [fragmentOutletRef]);
 
 	return (
 		<>
@@ -81,7 +94,7 @@ function App() {
 			<section style={{ display: 'flex', justifyContent: 'center' }}>
 				<div className="fragment-container pierced">
 					<h2>Reframed - from target</h2>
-					<fragment-outlet fragment-id="remix" />
+					<fragment-outlet fragment-id="remix" ref={fragmentOutletRef} />
 				</div>
 				<div className="fragment-container">
 					<div style={{ width: '100%' }}>

--- a/e2e/pierced-react/src/routes/root.tsx
+++ b/e2e/pierced-react/src/routes/root.tsx
@@ -18,6 +18,7 @@ function App() {
 				Note: Clicking this button should update the URL but not the UI.
 			</p>
 			<Link to="/remix-page">Remix Page</Link>
+			<Link to="/remix-error-page">Remix Error Page</Link>
 			<Link to="/qwik-page">Qwik Page</Link>
 		</div>
 	);

--- a/packages/web-fragments/src/elements/fragment-host.ts
+++ b/packages/web-fragments/src/elements/fragment-host.ts
@@ -22,6 +22,9 @@ export class FragmentHost extends HTMLElement {
 			const { iframe, ready } = reframed(this.shadowRoot ?? document.location.href, {
 				container: this,
 				headers: { 'x-fragment-mode': 'embedded' },
+				errorHandler: (error: Error) => {
+					this.dispatchEvent(new ErrorEvent('fragment-host-error', { error, bubbles: true, composed: true }));
+				},
 			});
 
 			this.iframe = iframe;

--- a/packages/web-fragments/src/elements/fragment-outlet.ts
+++ b/packages/web-fragments/src/elements/fragment-outlet.ts
@@ -1,24 +1,28 @@
 export class FragmentOutlet extends HTMLElement {
 	async connectedCallback() {
-		// TODO: remove this after fractus experiment is over.
-		// We had to put this here because the remix and qwik experiments
-		// both needed to render on the same route pattern, so we needed a way
-		// to differentiate between which fragment should be served by the gateway.
-		const fragmentId = this.getAttribute('fragment-id');
-		document.cookie = `fragment_id=${fragmentId};path=/`;
+		try {
+			// TODO: remove this after fractus experiment is over.
+			// We had to put this here because the remix and qwik experiments
+			// both needed to render on the same route pattern, so we needed a way
+			// to differentiate between which fragment should be served by the gateway.
+			const fragmentId = this.getAttribute('fragment-id');
+			document.cookie = `fragment_id=${fragmentId};path=/`;
 
-		if (!fragmentId) {
-			throw new Error('The fragment outlet component has been applied without' + ' providing a fragment-id');
-		}
+			if (!fragmentId) {
+				throw new Error('The fragment outlet component has been applied without' + ' providing a fragment-id');
+			}
 
-		const didNotPierce = this.dispatchEvent(new Event('fragment-outlet-ready', { bubbles: true, cancelable: true }));
+			const didNotPierce = this.dispatchEvent(new Event('fragment-outlet-ready', { bubbles: true, cancelable: true }));
 
-		// There is no <fragment-host> element mounted that needs to pierce into <fragment-outlet>.
-		// Instantiate a <fragment-host> element that can fetch the fragment via reframed
-		if (didNotPierce) {
-			const fragmentHost = document.createElement('fragment-host');
-			fragmentHost.setAttribute('fragment-id', fragmentId);
-			this.appendChild(fragmentHost);
+			// There is no <fragment-host> element mounted that needs to pierce into <fragment-outlet>.
+			// Instantiate a <fragment-host> element that can fetch the fragment via reframed
+			if (didNotPierce) {
+				const fragmentHost = document.createElement('fragment-host');
+				fragmentHost.setAttribute('fragment-id', fragmentId);
+				this.appendChild(fragmentHost);
+			}
+		} catch (error) {
+			this.dispatchEvent(new ErrorEvent('fragment-outlet-error', { bubbles: true, composed: true, error }));
 		}
 	}
 


### PR DESCRIPTION
Adds a way for errors to be passed through, up to the client host. This enables some client ErrorBoundary handling, like Sentry. This is most useful, when the initial fetching of a fragment fails, due to something like a misconfigured gateway endpoint, or something else in the network stack. 

An example can be seen in the e2e/pierced-react demo, at the new route http://localhost:8788/remix-error-page.