### PR TITLE
fix: correctly support MutationObserver and ResizeObserver

### DIFF
--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -424,6 +424,8 @@ function monkeyPatchIFrameEnvironment(iframe: HTMLIFrameElement, shadowRoot: Ref
 	});
 
 	iframeWindow.IntersectionObserver = mainWindow.IntersectionObserver;
+	iframeWindow.MutationObserver = mainWindow.MutationObserver;
+	iframeWindow.ResizeObserver = mainWindow.ResizeObserver;
 
 	const windowSizeProperties: (keyof Pick<Window, 'innerHeight' | 'innerWidth' | 'outerHeight' | 'outerWidth'>)[] = [
 		'innerHeight',


### PR DESCRIPTION
Previously we didn't patch these, and since they were asked to observe DOM from the main frame the observers didn't work correctly.