### PR TITLE
fix(reframed): document.activeElement should always point to shadowRoot.activeElement

### DIFF
--- a/.changeset/silver-lemons-sniff.md
+++ b/.changeset/silver-lemons-sniff.md
@@ -1,0 +1,10 @@
+---
+'reframed': patch
+'web-fragments': patch
+---
+
+fix(reframed): document.activeElement should always point to shadowRoot.activeElement
+
+Previously before we used shadowRoot in web fragments the active element in the fragment targeted main document's active element.
+But now that we require the use of shadowRoot, we must use shadowRoot.activeElement instead because otherwise activeElement is set to the element that owns the fragment's shadowroot.
+This issue caused the code in fragment to escape the shadowroot, which results in weird bugs.

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -302,8 +302,7 @@ function monkeyPatchIFrameEnvironment(iframe: HTMLIFrameElement, shadowRoot: Ref
 		// redirect to mainDocument
 		activeElement: {
 			get: () => {
-				// TODO: we see event.target during dispatchEvent to be set to null, it's likely due to this patch... investigate why!
-				return mainDocument.activeElement;
+				return shadowRoot.activeElement;
 			},
 		},
 


### PR DESCRIPTION
Previously before we used shadowRoot the active element in the fragment targeted main document's active element, but now that we require the use of shadowRoot, we must use shadowRoot.activeElement instead because otherwise activeElement is set to the element that owns the fragment's shadowroot. This causes the code in fragment to escape the shadowroot, which results in weird bugs.