### PR TITLE
fix(reframed): correctly execute external scripts (with src)

### DIFF
--- a/.changeset/great-carrots-protect.md
+++ b/.changeset/great-carrots-protect.md
@@ -1,0 +1,10 @@
+---
+'reframed': patch
+'web-fragments': patch
+---
+
+fix(reframed): correctly execute external scripts (`<script src="...">`)
+
+Previously we accidentally treated them as inline scripts that haven't been fully parsed and appended, which caused double execution of these scripts.
+
+This issue prevented Analog from bootstrapping correctly in reframed context.

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -653,7 +653,7 @@ function monkeyPatchDOMInsertionMethods() {
 		// Script nodes that do not have text content are not evaluated.
 		// Add a reference of the script to the iframe. If text content is added later, the script is then evaluated.
 		// Clone the empty script to the main document.
-		if (!script.textContent) {
+		if (!script.src && !script.textContent) {
 			const clone = document.importNode(script, true);
 			getInternalReference(iframe.contentDocument, 'body').appendChild(script);
 			return clone;


### PR DESCRIPTION
Previously we accidentally treated them as inline scripts that haven't been fully parsed and appended, which caused double execution of these scripts.

This issue prevented Analog from bootstrapping correctly in reframed context.