### PR TITLE
fix(reframed): node.ownerDocument should return return the fragment's shadowRoot

### DIFF
--- a/.changeset/sixty-phones-notice.md
+++ b/.changeset/sixty-phones-notice.md
@@ -1,0 +1,10 @@
+---
+'reframed': patch
+'web-fragments': patch
+---
+
+fix(reframed): node.ownerDocument should return fragment Document
+
+Any node within the fragment's shadowRoot should consider its ownerDocument to be the monkey patched Document from the reframed iframe.
+
+If we don't patch this, it's too easy for code to escape the shadowRoot boundary when traversing the DOM.

--- a/.changeset/swift-turtles-nail.md
+++ b/.changeset/swift-turtles-nail.md
@@ -1,0 +1,8 @@
+---
+'reframed': patch
+'web-fragments': patch
+---
+
+fix(reframed): node.getRootNode() should return fragment's Document
+
+This is to ensure consistent behavior with the real DOM.


### PR DESCRIPTION
Any node within the fragment's shadowRoot should consider its ownerDocument to be the shadowRoot.
If we don't patch this, it's too easy for code to escape the shadowRoot boundary when traversing the DOM.