### PR TITLE
build: fix reframed's vite config

### DIFF
--- a/packages/reframed/vite.config.ts
+++ b/packages/reframed/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
 	build: {
 		lib: {
-			entry: new URL(import.meta.resolve('./index.ts')).pathname,
+			entry: new URL('./index.ts', import.meta.url).pathname,
 			fileName: 'reframed',
 			formats: ['es'],
 		},


### PR DESCRIPTION
It seems that the recent vite introduced in bab0a9d changed the behavior and the built has been failing since.