### PR TITLE
fix(reframed): correctly support window.visualViewport

### DIFF
--- a/.changeset/modern-poets-rhyme.md
+++ b/.changeset/modern-poets-rhyme.md
@@ -1,0 +1,8 @@
+---
+'reframed': patch
+'web-fragments': patch
+---
+
+fix(reframed): correctly support window.visualViewport
+
+We need to read it from the main window.

--- a/packages/reframed/src/reframed.ts
+++ b/packages/reframed/src/reframed.ts
@@ -426,12 +426,10 @@ function monkeyPatchIFrameEnvironment(iframe: HTMLIFrameElement, shadowRoot: Ref
 	iframeWindow.MutationObserver = mainWindow.MutationObserver;
 	iframeWindow.ResizeObserver = mainWindow.ResizeObserver;
 
-	const windowSizeProperties: (keyof Pick<Window, 'innerHeight' | 'innerWidth' | 'outerHeight' | 'outerWidth'>)[] = [
-		'innerHeight',
-		'innerWidth',
-		'outerHeight',
-		'outerWidth',
-	];
+	const windowSizeProperties: (keyof Pick<
+		Window,
+		'innerHeight' | 'innerWidth' | 'outerHeight' | 'outerWidth' | 'visualViewport'
+	>)[] = ['innerHeight', 'innerWidth', 'outerHeight', 'outerWidth', 'visualViewport'];
 	for (const windowSizeProperty of windowSizeProperties) {
 		Object.defineProperty(iframeWindow, windowSizeProperty, {
 			get: function reframedWindowSizeGetter() {


### PR DESCRIPTION
We need to read it from the main window.