### PR TITLE
fix(reframed): rewrite queries for html,head,body to target wf-* custom elements

### DIFF
--- a/.changeset/tender-rings-impress.md
+++ b/.changeset/tender-rings-impress.md
@@ -1,0 +1,15 @@
+---
+'web-fragments': patch
+'reframed': patch
+'@onwidget/astrowind': patch
+---
+
+Because the main document can only have one html, head, and body element on the page, the browser will omit extra instances of those elements within the shadowRoot.
+
+Instead, a valid Document structure within the shadowRoot is provided via "fake" custom container elements injected by the gateway: wf-html, wf-head, and wf-body
+
+Application code that targets document.documentElement, document.body, and document.head should reference these custom container elements.
+
+Any CSS selectors used in document.querySelector and document.querySelectorAll are rewritten to selectively target these custom container elements as well.
+
+For example, `document.querySelector('html body.head')` will be rewritten to `document.querySelector('wf-html wf-body.head)`.

--- a/.github/workflows/playwright-web-fragments.yml
+++ b/.github/workflows/playwright-web-fragments.yml
@@ -1,5 +1,4 @@
-name: Web Fragments Tests
-
+name: Web Fragments Playground Tests
 on:
   push:
     branches:

--- a/.github/workflows/vitest-web-fragments.yml
+++ b/.github/workflows/vitest-web-fragments.yml
@@ -1,0 +1,24 @@
+name: Web Fragments Unit Tests
+on:
+  push:
+    branches: [main]
+    paths: ['packages/**']
+  pull_request:
+    branches: [main]
+    paths: ['packages/**']
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 'packages/web-fragments'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm install -g pnpm && pnpm install
+      - name: Run Unit Tests
+        run: pnpm run test:unit

--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -58,7 +58,8 @@
 		"path-to-regexp": "^6.2.2",
 		"ts-node-dev": "^2.0.0",
 		"typescript": "catalog:",
-		"vite": "catalog:"
+		"vite": "catalog:",
+		"vitest": "^3.0.5"
 	},
 	"author": "Igor Minar<i@igor.dev>",
 	"contributors": [

--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -43,6 +43,7 @@
 		"types:root": "tsc -p .",
 		"types:check": "pnpm types --noEmit --emitDeclarationOnly false",
 		"types": "pnpm run --filter web-fragments --parallel \"/^types:(?!check).*/\"",
+		"test:unit": "pnpm vitest run src",
 		"test:gateway": "pnpm -C test/gateway test",
 		"test:playground": "pnpm -C test/playground test",
 		"test-debug:gateway": "vitest test/gateway --test-timeout=0 --no-file-parallelism",
@@ -59,7 +60,7 @@
 		"ts-node-dev": "^2.0.0",
 		"typescript": "catalog:",
 		"vite": "catalog:",
-		"vitest": "^3.0.5"
+		"vitest": "catalog:"
 	},
 	"author": "Igor Minar<i@igor.dev>",
 	"contributors": [

--- a/packages/web-fragments/src/elements/reframed/reframed.ts
+++ b/packages/web-fragments/src/elements/reframed/reframed.ts
@@ -782,9 +782,13 @@ function monkeyPatchDOMInsertionMethods() {
 
 	// Rewrite the tagname for special custom elements added by writable-dom.
 	// Remove the WF-* prefix, but only for those elements.
+	//
+	// TODO: optimize patch for tagname rewrite to short circuit earlier,
+	// otherwise we potentially need to run this check millions/billions of times
+	const WF_CUSTOM_ELEMENTS = new Set(['WF-HTML', 'WF-HEAD', 'WF-BODY']);
 	function rewriteTagName(node: Element) {
 		const originalTagName = node.tagName;
-		if (['WF-HTML', 'WF-HEAD', 'WF-BODY'].includes(originalTagName)) {
+		if (WF_CUSTOM_ELEMENTS.has(originalTagName)) {
 			Object.defineProperty(node, 'tagName', {
 				get() {
 					return originalTagName.replace(/^WF-/i, '');

--- a/packages/web-fragments/src/elements/utils/selector-helpers.spec.ts
+++ b/packages/web-fragments/src/elements/utils/selector-helpers.spec.ts
@@ -11,7 +11,7 @@ describe('rewriteQuerySelector()', () => {
 		expect(rewriteQuerySelector('BODY')).toBe('wf-body');
 	});
 
-	test('Tag selectors with non-exact matches (bodybody) are ignored', () => {
+	test('Tag selectors with non-exact matches (bodybody) are preserved', () => {
 		expect(rewriteQuerySelector('bodybody')).toBe('bodybody');
 		expect(rewriteQuerySelector('htmlhead')).toBe('htmlhead');
 	});
@@ -42,21 +42,25 @@ describe('rewriteQuerySelector()', () => {
 		);
 	});
 
-	test('Class selectors (.body) are ignored', () => {
+	test('Class selectors (.body) are preserved', () => {
 		expect(rewriteQuerySelector('.body')).toBe('.body');
 		expect(rewriteQuerySelector('html body.body')).toBe('wf-html wf-body.body');
 	});
 
-	test('ID selectors (#body) are ignored', () => {
+	test('ID selectors (#body) are preserved', () => {
 		expect(rewriteQuerySelector('#body')).toBe('#body');
 		expect(rewriteQuerySelector('html body#body .body')).toBe('wf-html wf-body#body .body');
 	});
 
-	test('Attribute selectors ([data-attr="body"]) are ignored', () => {
+	test('Attribute selectors ([data-attr="body"]) are preserved', () => {
 		expect(rewriteQuerySelector('html > div [data-attr="body"]')).toBe('wf-html > div [data-attr="body"]');
 	});
 
-	test('Non-matched selectors (div, p, a) are ignored', () => {
+	test('Non-matched selectors (div, p, a) are preserved', () => {
 		expect(rewriteQuerySelector('div, p, a')).toBe('div, p, a');
+	});
+
+	test('Valid wf-(html|head|body) selectors are preserved', () => {
+		expect(rewriteQuerySelector('wf-html, wf-head + wf-body')).toBe('wf-html, wf-head + wf-body');
 	});
 });

--- a/packages/web-fragments/src/elements/utils/selector-helpers.spec.ts
+++ b/packages/web-fragments/src/elements/utils/selector-helpers.spec.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from 'vitest';
+import { rewriteQuerySelector } from './selector-helpers';
+
+describe('rewriteQuerySelector()', () => {
+	test('Tag selectors (body) are rewritten', () => {
+		expect(rewriteQuerySelector('html')).toBe('wf-html');
+		expect(rewriteQuerySelector('head')).toBe('wf-head');
+		expect(rewriteQuerySelector('body')).toBe('wf-body');
+
+		// tag selectors are case-insensitive
+		expect(rewriteQuerySelector('BODY')).toBe('wf-body');
+	});
+
+	test('Tag selectors with non-exact matches (bodybody) are ignored', () => {
+		expect(rewriteQuerySelector('bodybody')).toBe('bodybody');
+		expect(rewriteQuerySelector('htmlhead')).toBe('htmlhead');
+	});
+
+	test('Comma separated selectors (html, body) are rewritten', () => {
+		expect(rewriteQuerySelector('html, body')).toBe('wf-html, wf-body');
+	});
+
+	test('Descendant combinators (html body) are rewritten', () => {
+		expect(rewriteQuerySelector('html body')).toBe('wf-html wf-body');
+	});
+
+	test('Child combinators (html > body > div) are rewritten', () => {
+		expect(rewriteQuerySelector('html > body > div')).toBe('wf-html > wf-body > div');
+	});
+
+	test('Subsequent sibling combinators (head~body) are rewritten', () => {
+		expect(rewriteQuerySelector('html > head~body')).toBe('wf-html > wf-head~wf-body');
+	});
+
+	test('Next sibling combinators (head + body) are rewritten', () => {
+		expect(rewriteQuerySelector('head+body')).toBe('wf-head+wf-body');
+	});
+
+	test('Complex queries (body>head, .body+head > body:hover") are rewritten', () => {
+		expect(rewriteQuerySelector('body>head, .body+head > body:hover"')).toBe(
+			'wf-body>wf-head, .body+wf-head > wf-body:hover"',
+		);
+	});
+
+	test('Class selectors (.body) are ignored', () => {
+		expect(rewriteQuerySelector('.body')).toBe('.body');
+		expect(rewriteQuerySelector('html body.body')).toBe('wf-html wf-body.body');
+	});
+
+	test('ID selectors (#body) are ignored', () => {
+		expect(rewriteQuerySelector('#body')).toBe('#body');
+		expect(rewriteQuerySelector('html body#body .body')).toBe('wf-html wf-body#body .body');
+	});
+
+	test('Attribute selectors ([data-attr="body"]) are ignored', () => {
+		expect(rewriteQuerySelector('html > div [data-attr="body"]')).toBe('wf-html > div [data-attr="body"]');
+	});
+
+	test('Non-matched selectors (div, p, a) are ignored', () => {
+		expect(rewriteQuerySelector('div, p, a')).toBe('div, p, a');
+	});
+});

--- a/packages/web-fragments/src/elements/utils/selector-helpers.ts
+++ b/packages/web-fragments/src/elements/utils/selector-helpers.ts
@@ -1,0 +1,17 @@
+/**
+ * For CSS selectors that contain html, head, and body tag names, rewrite the selector with the wf-* prefix.
+ *
+ * Breakdown of the regex:
+ * (?<=^|[\s>+~,(]) - lookbehind to only match when preceded by start of string, whitespace and combinators
+ * \b(body|head|html)\b - match body|head|html exactly, but only at word boundaries
+ * (?=[\s>+~),:.#[\]]|$) - lookahead to only match when followed by start of string or combinators
+ */
+export const rewriteQuerySelector = (selector: string, prefix: string = 'wf') =>
+	selector.replace(
+		/(?<=^|[\s>+~,(])\b(body|head|html)\b(?=[\s>+~),:.#[\]]|$)/gi,
+		(match) => `${prefix}-${match.toLowerCase()}`,
+	);
+
+export const stripWFPrefix = (tagName: string) => {
+	return tagName.replace(/^wf-/i, '');
+};

--- a/packages/web-fragments/src/elements/utils/selector-helpers.ts
+++ b/packages/web-fragments/src/elements/utils/selector-helpers.ts
@@ -6,12 +6,8 @@
  * \b(body|head|html)\b - match body|head|html exactly, but only at word boundaries
  * (?=[\s>+~),:.#[\]]|$) - lookahead to only match when followed by start of string or combinators
  */
-export const rewriteQuerySelector = (selector: string, prefix: string = 'wf') =>
+export const rewriteQuerySelector = (selector: string) =>
 	selector.replace(
 		/(?<=^|[\s>+~,(])\b(body|head|html)\b(?=[\s>+~),:.#[\]]|$)/gi,
-		(match) => `${prefix}-${match.toLowerCase()}`,
+		(match) => `wf-${match.toLowerCase()}`,
 	);
-
-export const stripWFPrefix = (tagName: string) => {
-	return tagName.replace(/^wf-/i, '');
-};

--- a/packages/web-fragments/test/gateway/package.json
+++ b/packages/web-fragments/test/gateway/package.json
@@ -10,7 +10,7 @@
 		"@types/node": "^20.12.7",
 		"connect": "^3.7.0",
 		"express": "^4.21.2",
-		"vitest": "^3.0.5",
+		"vitest": "catalog:",
 		"vitest-fetch-mock": "^0.4.3"
 	}
 }

--- a/packages/web-fragments/test/playground/dom-querying/fragment.html
+++ b/packages/web-fragments/test/playground/dom-querying/fragment.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<title>dom-querying fragment</title>
+		<style>
+			wf-body {
+				display: block;
+				border: 1px dashed purple;
+				padding: 16px;
+				font-family:
+					system-ui,
+					-apple-system,
+					BlinkMacSystemFont,
+					'Segoe UI',
+					Roboto,
+					Oxygen,
+					Ubuntu,
+					Cantarell,
+					'Open Sans',
+					'Helvetica Neue',
+					sans-serif;
+				-webkit-font-smoothing: antialiased;
+				-webkit-text-size-adjust: none;
+			}
+
+			* {
+				margin: 0;
+			}
+
+			h2 {
+				margin-bottom: 16px;
+			}
+
+			h3 {
+				margin: 24px 0 8px;
+				font-weight: 600;
+			}
+
+			p {
+				font-size: 14px;
+			}
+
+			.assertion-container {
+				display: flex;
+				align-items: center;
+				gap: 4px;
+				margin: 8px 0;
+			}
+		</style>
+	</head>
+	<body>
+		<h2 id="fragment-heading">DOM-querying fragment</h2>
+		<section id="body" class="body">
+			<h3>document.documentElement assertions</h3>
+			<div class="assertion-container">
+				<p>document.documentElement.tagName === "HTML"</p>
+				<input id="document-element-tagname-checkbox" type="checkbox" />
+			</div>
+			<div class="assertion-container">
+				<p>document.querySelector('html') returns document.documentElement element</p>
+				<input id="document-element-query-html-checkbox" type="checkbox" />
+			</div>
+			<div class="assertion-container">
+				<p>document.querySelector('wf-html') returns document.documentElement element</p>
+				<input id="document-element-query-wfhtml-checkbox" type="checkbox" />
+			</div>
+
+			<h3>document.body assertions</h3>
+			<div class="assertion-container">
+				<p>document.body.tagName === "BODY"</p>
+				<input id="document-body-tagname-checkbox" type="checkbox" />
+			</div>
+			<div class="assertion-container">
+				<p>document.querySelector('body') returns document.body element</p>
+				<input id="document-body-query-body-checkbox" type="checkbox" />
+			</div>
+			<div class="assertion-container">
+				<p>document.querySelector('wf-body') returns document.body element</p>
+				<input id="document-body-query-wfbody-checkbox" type="checkbox" />
+			</div>
+
+			<h3>document.head assertions</h3>
+			<div class="assertion-container">
+				<p>document.head.tagName === "HEAD"</p>
+				<input id="document-head-tagname-checkbox" type="checkbox" />
+			</div>
+			<div class="assertion-container">
+				<p>document.querySelector('head') returns document.head element</p>
+				<input id="document-head-query-head-checkbox" type="checkbox" />
+			</div>
+			<div class="assertion-container">
+				<p>document.querySelector('wf-head') returns document.head element</p>
+				<input id="document-head-query-wfhead-checkbox" type="checkbox" />
+			</div>
+
+			<h3>Selectors</h3>
+			<div class="assertion-container">
+				<p>Child selector: document.querySelector('body > h2') returns h2 element</p>
+				<input id="child-selector-checkbox" type="checkbox" />
+			</div>
+
+			<div class="assertion-container">
+				<p>Descendant selector: document.querySelector('body h2') returns h2 element</p>
+				<input id="descendant-selector-checkbox" type="checkbox" />
+			</div>
+
+			<div class="assertion-container">
+				<p>Next sibling selector: document.querySelector('body > h2 + section') returns section</p>
+				<input id="next-sibling-selector-checkbox" type="checkbox" />
+			</div>
+
+			<div class="assertion-container">
+				<p>Class selector: document.querySelector('.body') returns body section (*not document.body)</p>
+				<input id="class-selector-checkbox" type="checkbox" />
+			</div>
+
+			<div class="assertion-container">
+				<p>ID selector: document.querySelector('#body') returns body section (*not document.body)</p>
+				<input id="id-selector-checkbox" type="checkbox" />
+			</div>
+		</section>
+
+		<script type="module">
+			// document.documentElement
+			let queryHtml = document.querySelector('html');
+			let queryWfHtml = document.querySelector('wf-html');
+			let documentElement = document.documentElement;
+			if (documentElement.tagName === 'HTML') {
+				document.getElementById('document-element-tagname-checkbox').checked = true;
+			}
+			if (documentElement === queryHtml) {
+				document.getElementById('document-element-query-html-checkbox').checked = true;
+			}
+			if (documentElement === queryWfHtml) {
+				document.getElementById('document-element-query-wfhtml-checkbox').checked = true;
+			}
+
+			// document.body
+			let queryBody = document.querySelector('body');
+			let queryWfBody = document.querySelector('wf-body');
+			let documentBody = document.body;
+			if (documentBody.tagName === 'BODY') {
+				document.getElementById('document-body-tagname-checkbox').checked = true;
+			}
+			if (documentBody === queryBody) {
+				document.getElementById('document-body-query-body-checkbox').checked = true;
+			}
+			if (documentBody === queryWfBody) {
+				document.getElementById('document-body-query-wfbody-checkbox').checked = true;
+			}
+
+			// document.body
+			let queryHead = document.querySelector('head');
+			let queryWfHead = document.querySelector('wf-head');
+			let documentHead = document.head;
+			if (documentHead.tagName === 'HEAD') {
+				document.getElementById('document-head-tagname-checkbox').checked = true;
+			}
+			if (documentHead === queryHead) {
+				document.getElementById('document-head-query-head-checkbox').checked = true;
+			}
+			if (documentHead === queryWfHead) {
+				document.getElementById('document-head-query-wfhead-checkbox').checked = true;
+			}
+
+			// querySelector()
+			const h2 = document.getElementById('fragment-heading');
+			const bodySection = document.getElementById('body');
+
+			if (document.querySelector('body > h2') === h2) {
+				document.getElementById('child-selector-checkbox').checked = true;
+			}
+
+			if (document.querySelector('body h2') === h2) {
+				document.getElementById('descendant-selector-checkbox').checked = true;
+			}
+
+			if (document.querySelector('body > h2 + section') === bodySection) {
+				document.getElementById('next-sibling-selector-checkbox').checked = true;
+			}
+
+			if (document.querySelector('.body') === bodySection) {
+				document.getElementById('class-selector-checkbox').checked = true;
+			}
+
+			if (document.querySelector('#body') === bodySection) {
+				document.getElementById('id-selector-checkbox').checked = true;
+			}
+		</script>
+	</body>
+</html>

--- a/packages/web-fragments/test/playground/dom-querying/index.html
+++ b/packages/web-fragments/test/playground/dom-querying/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+	<head></head>
+	<body>
+		<h1>WF Playground: DOM-querying</h1>
+
+		<web-fragment fragment-id="dom-querying"></web-fragment>
+
+		<script type="module">
+			import { initializeWebFragments } from 'web-fragments';
+			initializeWebFragments();
+		</script>
+	</body>
+</html>

--- a/packages/web-fragments/test/playground/dom-querying/spec.ts
+++ b/packages/web-fragments/test/playground/dom-querying/spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+const { beforeEach, step } = test;
+import { failOnBrowserErrors } from '../playwright.utils';
+
+beforeEach(failOnBrowserErrors);
+
+test('DOM querying in fragments', async ({ page }) => {
+	await page.goto('/dom-querying/');
+
+	await step('ensure the test harness app loaded', async () => {
+		await expect(page.locator('h1')).toHaveText('WF Playground: DOM-querying');
+	});
+
+	const fragment = page.locator('web-fragment');
+
+	await step('ensure the dom-querying fragment renders', async () => {
+		await expect(fragment.locator('h2')).toHaveText('DOM-querying fragment');
+	});
+
+	await step('ensure document.documentElement is patched to return wf-html', async () => {
+		await expect(fragment.locator('#document-element-tagname-checkbox')).toBeChecked();
+		await expect(fragment.locator('#document-element-query-html-checkbox')).toBeChecked();
+		await expect(fragment.locator('#document-element-query-wfhtml-checkbox')).toBeChecked();
+	});
+
+	await step('ensure document.body is patched to return wf-body', async () => {
+		await expect(fragment.locator('#document-body-tagname-checkbox')).toBeChecked();
+		await expect(fragment.locator('#document-body-query-body-checkbox')).toBeChecked();
+		await expect(fragment.locator('#document-body-query-wfbody-checkbox')).toBeChecked();
+	});
+
+	await step('ensure document.head is patched to return wf-head', async () => {
+		await expect(fragment.locator('#document-head-tagname-checkbox')).toBeChecked();
+		await expect(fragment.locator('#document-head-query-head-checkbox')).toBeChecked();
+		await expect(fragment.locator('#document-head-query-wfhead-checkbox')).toBeChecked();
+	});
+
+	await step('ensure document.querySelector() is patched to replace html,body,head elements', async () => {
+		await expect(fragment.locator('#child-selector-checkbox')).toBeChecked();
+		await expect(fragment.locator('#descendant-selector-checkbox')).toBeChecked();
+		await expect(fragment.locator('#next-sibling-selector-checkbox')).toBeChecked();
+		await expect(fragment.locator('#class-selector-checkbox')).toBeChecked();
+		await expect(fragment.locator('#id-selector-checkbox')).toBeChecked();
+	});
+});

--- a/packages/web-fragments/test/playground/index.html
+++ b/packages/web-fragments/test/playground/index.html
@@ -17,6 +17,9 @@
 				>)
 			</li>
 			<li><a href="/dom-isolation/">/dom-isolation/</a> (<a href="/dom-isolation/fragment">fragment</a>)</li>
+
+			<li><a href="/dom-querying/">/dom-querying/</a> (<a href="/dom-querying/fragment">fragment</a>)</li>
+
 			<li><a href="/script-loading/">/script-loading/</a> (<a href="/script-loading/fragment">fragment</a>)</li>
 			<li>
 				<a href="/script-isolation/">/script-isolation/</a> (<a href="/script-isolation/fragment-a">fragment a</a>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     vite:
       specifier: 6.0.7
       version: 6.0.7
+    vitest:
+      specifier: ^3.0.5
+      version: 3.0.5
     wrangler:
       specifier: 3.109.3
       version: 3.109.3
@@ -414,7 +417,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.7(@types/node@20.14.10)(jiti@1.21.6)(lightningcss@1.27.0)(terser@5.34.1)(yaml@2.6.1)
       vitest:
-        specifier: ^3.0.5
+        specifier: 'catalog:'
         version: 3.0.5(@types/debug@4.1.12)(@types/node@20.14.10)(lightningcss@1.27.0)(terser@5.34.1)
 
   packages/web-fragments/test/gateway:
@@ -432,7 +435,7 @@ importers:
         specifier: ^4.21.2
         version: 4.21.2
       vitest:
-        specifier: ^3.0.5
+        specifier: 'catalog:'
         version: 3.0.5(@types/debug@4.1.12)(@types/node@20.14.10)(lightningcss@1.27.0)(terser@5.34.1)
       vitest-fetch-mock:
         specifier: ^0.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 6.0.7(@types/node@20.14.10)(jiti@1.21.6)(lightningcss@1.27.0)(terser@5.34.1)(yaml@2.6.1)
+      vitest:
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@20.14.10)(lightningcss@1.27.0)(terser@5.34.1)
 
   packages/web-fragments/test/gateway:
     devDependencies:
@@ -923,101 +926,101 @@ packages:
     resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
 
   '@cloudflare/kv-asset-handler@0.3.4':
-    resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
+    resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==, tarball: https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz}
     engines: {node: '>=16.13'}
 
   '@cloudflare/workerd-darwin-64@1.20240701.0':
-    resolution: {integrity: sha512-XAZa4ZP+qyTn6JQQACCPH09hGZXP2lTnWKkmg5mPwT8EyRzCKLkczAf98vPP5bq7JZD/zORdFWRY0dOTap8zTQ==}
+    resolution: {integrity: sha512-XAZa4ZP+qyTn6JQQACCPH09hGZXP2lTnWKkmg5mPwT8EyRzCKLkczAf98vPP5bq7JZD/zORdFWRY0dOTap8zTQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240701.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-64@1.20241205.0':
-    resolution: {integrity: sha512-TArEZkSZkHJyEwnlWWkSpCI99cF6lJ14OVeEoI9Um/+cD9CKZLM9vCmsLeKglKheJ0KcdCnkA+DbeD15t3VaWg==}
+    resolution: {integrity: sha512-TArEZkSZkHJyEwnlWWkSpCI99cF6lJ14OVeEoI9Um/+cD9CKZLM9vCmsLeKglKheJ0KcdCnkA+DbeD15t3VaWg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241205.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-64@1.20250214.0':
-    resolution: {integrity: sha512-cDvvedWDc5zrgDnuXe2qYcz/TwBvzmweO55C7XpPuAWJ9Oqxv81PkdekYxD8mH989aQ/GI5YD0Fe6fDYlM+T3Q==}
+    resolution: {integrity: sha512-cDvvedWDc5zrgDnuXe2qYcz/TwBvzmweO55C7XpPuAWJ9Oqxv81PkdekYxD8mH989aQ/GI5YD0Fe6fDYlM+T3Q==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250214.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20240701.0':
-    resolution: {integrity: sha512-w80ZVAgfH4UwTz7fXZtk7KmS2FzlXniuQm4ku4+cIgRTilBAuKqjpOjwUCbx5g13Gqcm9NuiHce+IDGtobRTIQ==}
+    resolution: {integrity: sha512-w80ZVAgfH4UwTz7fXZtk7KmS2FzlXniuQm4ku4+cIgRTilBAuKqjpOjwUCbx5g13Gqcm9NuiHce+IDGtobRTIQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240701.0.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20241205.0':
-    resolution: {integrity: sha512-u5eqKa9QRdA8MugfgCoD+ADDjY6EpKbv3hSYJETmmUh17l7WXjWBzv4pUvOKIX67C0UzMUy4jZYwC53MymhX3w==}
+    resolution: {integrity: sha512-u5eqKa9QRdA8MugfgCoD+ADDjY6EpKbv3hSYJETmmUh17l7WXjWBzv4pUvOKIX67C0UzMUy4jZYwC53MymhX3w==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241205.0.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20250214.0':
-    resolution: {integrity: sha512-NytCvRveVzu0mRKo+tvZo3d/gCUway3B2ZVqSi/TS6NXDGBYIJo7g6s3BnTLS74kgyzeDOjhu9j/RBJBS809qw==}
+    resolution: {integrity: sha512-NytCvRveVzu0mRKo+tvZo3d/gCUway3B2ZVqSi/TS6NXDGBYIJo7g6s3BnTLS74kgyzeDOjhu9j/RBJBS809qw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250214.0.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-linux-64@1.20240701.0':
-    resolution: {integrity: sha512-UWLr/Anxwwe/25nGv451MNd2jhREmPt/ws17DJJqTLAx6JxwGWA15MeitAIzl0dbxRFAJa+0+R8ag2WR3F/D6g==}
+    resolution: {integrity: sha512-UWLr/Anxwwe/25nGv451MNd2jhREmPt/ws17DJJqTLAx6JxwGWA15MeitAIzl0dbxRFAJa+0+R8ag2WR3F/D6g==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240701.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
   '@cloudflare/workerd-linux-64@1.20241205.0':
-    resolution: {integrity: sha512-OYA7S5zpumMamWEW+IhhBU6YojIEocyE5X/YFPiTOCrDE3dsfr9t6oqNE7hxGm1VAAu+Irtl+a/5LwmBOU681w==}
+    resolution: {integrity: sha512-OYA7S5zpumMamWEW+IhhBU6YojIEocyE5X/YFPiTOCrDE3dsfr9t6oqNE7hxGm1VAAu+Irtl+a/5LwmBOU681w==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241205.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
   '@cloudflare/workerd-linux-64@1.20250214.0':
-    resolution: {integrity: sha512-pQ7+aHNHj8SiYEs4d/6cNoimE5xGeCMfgU1yfDFtA9YGN9Aj2BITZgOWPec+HW7ZkOy9oWlNrO6EvVjGgB4tbQ==}
+    resolution: {integrity: sha512-pQ7+aHNHj8SiYEs4d/6cNoimE5xGeCMfgU1yfDFtA9YGN9Aj2BITZgOWPec+HW7ZkOy9oWlNrO6EvVjGgB4tbQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250214.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20240701.0':
-    resolution: {integrity: sha512-3kCnF9kYgov1ggpuWbgpXt4stPOIYtVmPCa7MO2xhhA0TWP6JDUHRUOsnmIgKrvDjXuXqlK16cdg3v+EWsaPJg==}
+    resolution: {integrity: sha512-3kCnF9kYgov1ggpuWbgpXt4stPOIYtVmPCa7MO2xhhA0TWP6JDUHRUOsnmIgKrvDjXuXqlK16cdg3v+EWsaPJg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240701.0.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20241205.0':
-    resolution: {integrity: sha512-qAzecONjFJGIAVJZKExQ5dlbic0f3d4A+GdKa+H6SoUJtPaWiE3K6WuePo4JOT7W3/Zfh25McmX+MmpMUUcM5Q==}
+    resolution: {integrity: sha512-qAzecONjFJGIAVJZKExQ5dlbic0f3d4A+GdKa+H6SoUJtPaWiE3K6WuePo4JOT7W3/Zfh25McmX+MmpMUUcM5Q==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241205.0.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20250214.0':
-    resolution: {integrity: sha512-Vhlfah6Yd9ny1npNQjNgElLIjR6OFdEbuR3LCfbLDCwzWEBFhIf7yC+Tpp/a0Hq7kLz3sLdktaP7xl3PJhyOjA==}
+    resolution: {integrity: sha512-Vhlfah6Yd9ny1npNQjNgElLIjR6OFdEbuR3LCfbLDCwzWEBFhIf7yC+Tpp/a0Hq7kLz3sLdktaP7xl3PJhyOjA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250214.0.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-windows-64@1.20240701.0':
-    resolution: {integrity: sha512-6IPGITRAeS67j3BH1rN4iwYWDt47SqJG7KlZJ5bB4UaNAia4mvMBSy/p2p4vA89bbXoDRjMtEvRu7Robu6O7hQ==}
+    resolution: {integrity: sha512-6IPGITRAeS67j3BH1rN4iwYWDt47SqJG7KlZJ5bB4UaNAia4mvMBSy/p2p4vA89bbXoDRjMtEvRu7Robu6O7hQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240701.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
   '@cloudflare/workerd-windows-64@1.20241205.0':
-    resolution: {integrity: sha512-BEab+HiUgCdl6GXAT7EI2yaRtDPiRJlB94XLvRvXi1ZcmQqsrq6awGo6apctFo4WUL29V7c09LxmN4HQ3X2Tvg==}
+    resolution: {integrity: sha512-BEab+HiUgCdl6GXAT7EI2yaRtDPiRJlB94XLvRvXi1ZcmQqsrq6awGo6apctFo4WUL29V7c09LxmN4HQ3X2Tvg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241205.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
   '@cloudflare/workerd-windows-64@1.20250214.0':
-    resolution: {integrity: sha512-GMwMyFbkjBKjYJoKDhGX8nuL4Gqe3IbVnVWf2Q6086CValyIknupk5J6uQWGw2EBU3RGO3x4trDXT5WphQJZDQ==}
+    resolution: {integrity: sha512-GMwMyFbkjBKjYJoKDhGX8nuL4Gqe3IbVnVWf2Q6086CValyIknupk5J6uQWGw2EBU3RGO3x4trDXT5WphQJZDQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250214.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
   '@cloudflare/workers-types@4.20250224.0':
-    resolution: {integrity: sha512-j6ZwQ5G2moQRaEtGI2u5TBQhVXv/XwOS5jfBAheZHcpCM07zm8j0i8jZHHLq/6VA8e6VRjKohOyj5j6tZ1KHLQ==}
+    resolution: {integrity: sha512-j6ZwQ5G2moQRaEtGI2u5TBQhVXv/XwOS5jfBAheZHcpCM07zm8j0i8jZHHLq/6VA8e6VRjKohOyj5j6tZ1KHLQ==, tarball: https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250224.0.tgz}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2033,11 +2036,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.28.1':
-    resolution: {integrity: sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.34.6':
     resolution: {integrity: sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==}
     cpu: [arm]
@@ -2045,11 +2043,6 @@ packages:
 
   '@rollup/rollup-android-arm64@4.18.0':
     resolution: {integrity: sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.28.1':
-    resolution: {integrity: sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==}
     cpu: [arm64]
     os: [android]
 
@@ -2063,11 +2056,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.28.1':
-    resolution: {integrity: sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.34.6':
     resolution: {integrity: sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==}
     cpu: [arm64]
@@ -2078,29 +2066,14 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.28.1':
-    resolution: {integrity: sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==}
-    cpu: [x64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-x64@4.34.6':
     resolution: {integrity: sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.28.1':
-    resolution: {integrity: sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.34.6':
     resolution: {integrity: sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.28.1':
-    resolution: {integrity: sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.34.6':
@@ -2110,11 +2083,6 @@ packages:
 
   '@rollup/rollup-linux-arm-gnueabihf@4.18.0':
     resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.28.1':
-    resolution: {integrity: sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==}
     cpu: [arm]
     os: [linux]
 
@@ -2128,11 +2096,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.28.1':
-    resolution: {integrity: sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-musleabihf@4.34.6':
     resolution: {integrity: sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==}
     cpu: [arm]
@@ -2140,11 +2103,6 @@ packages:
 
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.28.1':
-    resolution: {integrity: sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2158,19 +2116,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.28.1':
-    resolution: {integrity: sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-musl@4.34.6':
     resolution: {integrity: sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==}
     cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loongarch64-gnu@4.28.1':
-    resolution: {integrity: sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==}
-    cpu: [loong64]
     os: [linux]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.6':
@@ -2180,11 +2128,6 @@ packages:
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-powerpc64le-gnu@4.28.1':
-    resolution: {integrity: sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==}
     cpu: [ppc64]
     os: [linux]
 
@@ -2198,11 +2141,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.28.1':
-    resolution: {integrity: sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==}
-    cpu: [riscv64]
-    os: [linux]
-
   '@rollup/rollup-linux-riscv64-gnu@4.34.6':
     resolution: {integrity: sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==}
     cpu: [riscv64]
@@ -2210,11 +2148,6 @@ packages:
 
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@rollup/rollup-linux-s390x-gnu@4.28.1':
-    resolution: {integrity: sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==}
     cpu: [s390x]
     os: [linux]
 
@@ -2228,11 +2161,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.28.1':
-    resolution: {integrity: sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.34.6':
     resolution: {integrity: sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==}
     cpu: [x64]
@@ -2240,11 +2168,6 @@ packages:
 
   '@rollup/rollup-linux-x64-musl@4.18.0':
     resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.28.1':
-    resolution: {integrity: sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==}
     cpu: [x64]
     os: [linux]
 
@@ -2258,11 +2181,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.28.1':
-    resolution: {integrity: sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.34.6':
     resolution: {integrity: sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==}
     cpu: [arm64]
@@ -2273,11 +2191,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.28.1':
-    resolution: {integrity: sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.34.6':
     resolution: {integrity: sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==}
     cpu: [ia32]
@@ -2285,11 +2198,6 @@ packages:
 
   '@rollup/rollup-win32-x64-msvc@4.18.0':
     resolution: {integrity: sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.28.1':
-    resolution: {integrity: sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==}
     cpu: [x64]
     os: [win32]
 
@@ -6676,11 +6584,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.28.1:
-    resolution: {integrity: sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.34.6:
     resolution: {integrity: sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -8001,7 +7904,7 @@ snapshots:
   '@antfu/install-pkg@0.4.1':
     dependencies:
       package-manager-detector: 0.2.7
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
 
   '@antfu/utils@0.7.10': {}
 
@@ -8234,7 +8137,7 @@ snapshots:
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   '@babel/compat-data@7.24.7': {}
 
@@ -9414,7 +9317,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -9433,12 +9336,12 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jspm/core@2.0.1': {}
 
@@ -9780,7 +9683,7 @@ snapshots:
 
   '@rollup/pluginutils@5.1.3(rollup@4.34.6)':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 4.0.2
     optionalDependencies:
@@ -9789,16 +9692,10 @@ snapshots:
   '@rollup/rollup-android-arm-eabi@4.18.0':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.28.1':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.34.6':
     optional: true
 
   '@rollup/rollup-android-arm64@4.18.0':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.28.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.34.6':
@@ -9807,28 +9704,16 @@ snapshots:
   '@rollup/rollup-darwin-arm64@4.18.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.28.1':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.34.6':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.18.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.28.1':
-    optional: true
-
   '@rollup/rollup-darwin-x64@4.34.6':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.28.1':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.34.6':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.28.1':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.34.6':
@@ -9837,16 +9722,10 @@ snapshots:
   '@rollup/rollup-linux-arm-gnueabihf@4.18.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.28.1':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.34.6':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.28.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.6':
@@ -9855,22 +9734,13 @@ snapshots:
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.28.1':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.34.6':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.18.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.28.1':
-    optional: true
-
   '@rollup/rollup-linux-arm64-musl@4.34.6':
-    optional: true
-
-  '@rollup/rollup-linux-loongarch64-gnu@4.28.1':
     optional: true
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.6':
@@ -9879,16 +9749,10 @@ snapshots:
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.28.1':
-    optional: true
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.6':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.28.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.6':
@@ -9897,16 +9761,10 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.28.1':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.34.6':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.18.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.28.1':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.34.6':
@@ -9915,16 +9773,10 @@ snapshots:
   '@rollup/rollup-linux-x64-musl@4.18.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.28.1':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.34.6':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.18.0':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.28.1':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.34.6':
@@ -9933,16 +9785,10 @@ snapshots:
   '@rollup/rollup-win32-ia32-msvc@4.18.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.28.1':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.34.6':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.18.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.28.1':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.34.6':
@@ -13762,7 +13608,7 @@ snapshots:
     dependencies:
       '@babel/parser': 7.26.3
       '@babel/types': 7.26.3
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   make-error@1.3.6: {}
 
@@ -15802,31 +15648,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.18.0
       fsevents: 2.3.3
 
-  rollup@4.28.1:
-    dependencies:
-      '@types/estree': 1.0.6
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.28.1
-      '@rollup/rollup-android-arm64': 4.28.1
-      '@rollup/rollup-darwin-arm64': 4.28.1
-      '@rollup/rollup-darwin-x64': 4.28.1
-      '@rollup/rollup-freebsd-arm64': 4.28.1
-      '@rollup/rollup-freebsd-x64': 4.28.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.28.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.28.1
-      '@rollup/rollup-linux-arm64-gnu': 4.28.1
-      '@rollup/rollup-linux-arm64-musl': 4.28.1
-      '@rollup/rollup-linux-loongarch64-gnu': 4.28.1
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.28.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.28.1
-      '@rollup/rollup-linux-s390x-gnu': 4.28.1
-      '@rollup/rollup-linux-x64-gnu': 4.28.1
-      '@rollup/rollup-linux-x64-musl': 4.28.1
-      '@rollup/rollup-win32-arm64-msvc': 4.28.1
-      '@rollup/rollup-win32-ia32-msvc': 4.28.1
-      '@rollup/rollup-win32-x64-msvc': 4.28.1
-      fsevents: 2.3.3
-
   rollup@4.34.6:
     dependencies:
       '@types/estree': 1.0.6
@@ -16961,8 +16782,8 @@ snapshots:
   vite@5.4.11(@types/node@20.14.10)(lightningcss@1.27.0)(terser@5.34.1):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.28.1
+      postcss: 8.5.1
+      rollup: 4.34.6
     optionalDependencies:
       '@types/node': 20.14.10
       fsevents: 2.3.3
@@ -16972,8 +16793,8 @@ snapshots:
   vite@5.4.11(@types/node@22.13.0)(lightningcss@1.27.0)(terser@5.34.1):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.28.1
+      postcss: 8.5.1
+      rollup: 4.34.6
     optionalDependencies:
       '@types/node': 22.13.0
       fsevents: 2.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
 catalog:
   typescript: 5.5.4
   vite: 6.0.7
+  vitest: ^3.0.5
   wrangler: 3.109.3
   '@playwright/test': 1.49.1
   '@cloudflare/workers-types': 4.20250224.0


### PR DESCRIPTION
CSS selectors used in `querySelector` and `querySelectorAll` are patched to replace html, head, and body tags with their wf-* custom element counterpart.

`document.documentElement`, `document.body`, and `document.head` are also patched to return references to valid elements. These references are cached when a valid element is found in order to reduce lookup time.