### PR TITLE
feat/web fragment src

### DIFF
--- a/.changeset/popular-buckets-try.md
+++ b/.changeset/popular-buckets-try.md
@@ -1,0 +1,13 @@
+---
+'web-fragments': patch
+---
+
+feat: add support for unbound fragments
+
+Unbound fragments are fragments that don't have their location, history, navigation, and routing bound to the shell application.
+
+This means that unbound fragments have independent history and navigation that is not represented in browsers address bar, and is not navigable via back and forward buttons/gestures.
+
+This kind of fragments are useful for auxiliary UI fragments that might have a complex inner state and routing but this state is ephemeral and doesn't need to be preserved during hard reloads.
+
+Good examples of these use-cases are chat bots, various side panels, assistants, etc.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@onwidget/astrowind",
-	"version": "1.0.0-beta.48",
 	"description": "AstroWind: A free template using Astro 4.0 and Tailwind CSS. Astro starter theme.",
 	"type": "module",
 	"private": true,

--- a/e2e/node-servers/app/client/package.json
+++ b/e2e/node-servers/app/client/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "node-servers-client",
 	"private": true,
-	"version": "1.0.1",
 	"description": "",
 	"type": "module",
 	"scripts": {

--- a/e2e/node-servers/package.json
+++ b/e2e/node-servers/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "node-servers",
 	"private": true,
-	"version": "1.0.1",
 	"type": "module",
 	"scripts": {
 		"dev:express": "node --loader ts-node/esm app/server/src/express.ts",

--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -45,7 +45,8 @@
 		"types": "pnpm run --filter web-fragments --parallel \"/^types:(?!check).*/\"",
 		"test:gateway": "pnpm -C test/gateway test",
 		"test:playground": "pnpm -C test/playground test",
-		"test-debug:gateway": "vitest test/gateway --test-timeout=0 --no-file-parallelism"
+		"test-debug:gateway": "vitest test/gateway --test-timeout=0 --no-file-parallelism",
+		"changeset": "pnpm -C ../../ exec changeset"
 	},
 	"dependencies": {
 		"htmlrewriter": "anfibiacreativa/htmlrewriter#fix-emoji-crash",

--- a/packages/web-fragments/src/elements/web-fragment-host.ts
+++ b/packages/web-fragments/src/elements/web-fragment-host.ts
@@ -19,9 +19,12 @@ export class WebFragmentHost extends HTMLElement {
 		if (!this.isInitialized) {
 			this.isInitialized = true;
 
-			const { iframe, ready } = reframed(this.shadowRoot ?? document.location.href, {
+			const fragmentSrc = this.getAttribute('src') ? this.getAttribute('src') : null;
+
+			const { iframe, ready } = reframed(this.shadowRoot ?? fragmentSrc ?? document.location.href, {
 				container: this,
 				headers: { 'x-fragment-mode': 'embedded' },
+				bound: !fragmentSrc,
 			});
 
 			// TODO: is this the best way to expose the reframed iframe? review and discuss...

--- a/packages/web-fragments/src/elements/web-fragment.ts
+++ b/packages/web-fragments/src/elements/web-fragment.ts
@@ -4,6 +4,7 @@
 export class WebFragment extends HTMLElement {
 	async connectedCallback() {
 		const fragmentId = this.getAttribute('fragment-id');
+		const fragmentSrc = this.getAttribute('src');
 
 		if (!fragmentId) {
 			throw new Error('The <web-fragment> is missing fragment-id attribute!');
@@ -14,13 +15,18 @@ export class WebFragment extends HTMLElement {
 		this.style.display = 'block';
 		this.style.position = 'relative';
 
-		const didNotPierce = this.dispatchEvent(new Event('fragment-outlet-ready', { bubbles: true, cancelable: true }));
+		const piercedHostNotFound = this.dispatchEvent(
+			new Event('fragment-outlet-ready', { bubbles: true, cancelable: true }),
+		);
 
-		// There is no <web-fragment-host> element mounted that needs to pierce into <fragment-outlet>.
-		// Instantiate a <web-fragment-host> element that can fetch the fragment via reframed
-		if (didNotPierce) {
+		// There is no <web-fragment-host> element in the document that could be adopted into this <web-fragment>.
+		// Instantiate a new <web-fragment-host> element to fetch the fragment
+		if (piercedHostNotFound) {
 			const fragmentHost = document.createElement('web-fragment-host');
 			fragmentHost.setAttribute('fragment-id', fragmentId);
+			if (fragmentSrc) {
+				fragmentHost.setAttribute('src', fragmentSrc);
+			}
 			this.appendChild(fragmentHost);
 		}
 

--- a/packages/web-fragments/test/playground/location-and-history/index.html
+++ b/packages/web-fragments/test/playground/location-and-history/index.html
@@ -41,9 +41,8 @@
 		<!-- bound fragment -->
 		<web-fragment fragment-id="location-and-history"></web-fragment>
 
-		<!-- standalone fragment -->
-		<!-- TODO: commented out for now since we don't support standalone fragments yet -->
-		<!-- <web-fragment src="/location-and-history/standalone"></web-fragment> -->
+		<!-- unbound fragment -->
+		<web-fragment fragment-id="unbound" src="/location-and-history/unbound"></web-fragment>
 
 		<script type="module">
 			import { initializeWebFragments } from 'web-fragments';

--- a/packages/web-fragments/test/playground/location-and-history/unbound.html
+++ b/packages/web-fragments/test/playground/location-and-history/unbound.html
@@ -2,11 +2,12 @@
 <html>
 	<head>
 		<meta charset="UTF-8" />
-		<title>standalone fragment</title>
+		<title>unbound fragment</title>
 	</head>
 	<body>
-		<h2>standalone fragment</h2>
+		<h2>unbound fragment</h2>
 		<p>location.href: <span></span></p>
+		<p>popstate count: <span id="popstate">0</span></p>
 		<button id="foo">go to /foo</button>
 		<button id="bar">go to /bar</button>
 		<script>
@@ -15,6 +16,11 @@
 			}
 
 			setInterval(rerenderLocationHref, 100);
+
+			let popstateCount = 0;
+			window.addEventListener('popstate', () => {
+				document.getElementById('popstate').textContent = ++popstateCount;
+			});
 
 			document.querySelector('button#foo').addEventListener('click', () => {
 				history.pushState({}, '', '/foo');


### PR DESCRIPTION
feat: add support for unbound fragments
Unbound fragments are fragments that don't have their location, history, navigation, and routing bound to the shell application.

This means that unbound fragments have independent history and navigation that is not represented in browsers address bar, and is not navigable via back and forward buttons/gestures.

This kind of fragments are useful for auxiliary UI fragments that might have a complex inner state and routing but this state is ephemeral and doesn't need to be preserved during hard reloads.

Good examples of these use-cases are chat bots, various side panels, assistants, etc.