### PR TITLE
dev: add prepare script to the web-fragments npm package

### DIFF
--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -46,7 +46,8 @@
 		"test:gateway": "pnpm -C test/gateway test",
 		"test:playground": "pnpm -C test/playground test",
 		"test-debug:gateway": "vitest test/gateway --test-timeout=0 --no-file-parallelism",
-		"changeset": "pnpm -C ../../ exec changeset"
+		"changeset": "pnpm -C ../../ exec changeset",
+		"prepare": "pnpm build"
 	},
 	"dependencies": {
 		"htmlrewriter": "anfibiacreativa/htmlrewriter#fix-emoji-crash",


### PR DESCRIPTION
This enables the package to be depended upon via github url without a release with the following version specifier:

github:igorminar/web-fragments#angular-fixes&path:packages/web-fragments