### PR TITLE
dev: remove obsolete changelog entries

### DIFF
--- a/.changeset/fluffy-guests-burn.md
+++ b/.changeset/fluffy-guests-burn.md
@@ -1,6 +1,5 @@
 ---
 'web-fragments': patch
-'reframed': patch
 ---
 
 fix(reframed): don't create an superfluous browser history record in firefox

--- a/.changeset/strange-games-lie.md
+++ b/.changeset/strange-games-lie.md
@@ -1,6 +1,5 @@
 ---
 'web-fragments': minor
-'reframed': minor
 ---
 
 feat(web-fragments): all fragments have css style display:block and position:relative set on the host

--- a/e2e/node-servers/CHANGELOG.md
+++ b/e2e/node-servers/CHANGELOG.md
@@ -1,8 +1,0 @@
-# node-servers
-
-## 1.0.1
-
-### Patch Changes
-
-- Updated dependencies [[`6644f9d`](https://github.com/web-fragments/web-fragments/commit/6644f9daf739ed3036022264f6cef2f88af586ee)]:
-  - web-fragments@0.3.0

--- a/e2e/node-servers/app/client/CHANGELOG.md
+++ b/e2e/node-servers/app/client/CHANGELOG.md
@@ -1,8 +1,0 @@
-# node-servers-client
-
-## 1.0.1
-
-### Patch Changes
-
-- Updated dependencies [[`6644f9d`](https://github.com/web-fragments/web-fragments/commit/6644f9daf739ed3036022264f6cef2f88af586ee)]:
-  - web-fragments@0.3.0


### PR DESCRIPTION
these were created accidentaly or are leftovers from having reframed library in the repo