### PR TITLE
fix: fix types path for node middleware

### DIFF
--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -25,7 +25,7 @@
 			},
 			"./gateway/node": {
 				"import": "./dist/gateway/node.js",
-				"types": "./dist/gateway/node.d.ts"
+				"types": "./dist/gateway/middleware/node.d.ts"
 			}
 		}
 	},


### PR DESCRIPTION
This PR fixes the path to the node middleware type declaration