### PR TITLE
fix: correctly handle hard navigations and reloads from fragments

### DIFF
--- a/.changeset/slow-kings-hope.md
+++ b/.changeset/slow-kings-hope.md
@@ -1,0 +1,19 @@
+---
+'web-fragments': patch
+---
+
+fix: correctly handle hard navigations and reloads from fragments
+
+Previously a hard navigation (`location.href = '/new-url'`) or location reload (`location.reload()`)
+within a (bound) fragment would result in this fragment getting into a broken state.
+
+The root cause was that navigation would cause the reframed iframe reloaded,
+unloading all JS code but the DOM remained unchanged.
+
+This resulted in broken UX.
+
+With this change any hard navigation or reload within a bound fragment will
+be propagated to the main window, causing a hard navigation or reload in the app shell.
+
+It's a bit unclear what should happen when this kind of navigation happens in an unbound fragment.
+For this reasons, we only empty the fragment DOM for now and log a warning.

--- a/packages/web-fragments/test/playground/location-and-history/fragment.html
+++ b/packages/web-fragments/test/playground/location-and-history/fragment.html
@@ -8,8 +8,10 @@
 		<h2>bound fragment</h2>
 		<p>location.href: <span id="href"></span></p>
 		<p>popstate count: <span id="popstate">0</span></p>
-		<button id="foo">go to /foo</button>
-		<button id="bar">go to /bar</button>
+		<button id="softNavToFoo">soft nav to /foo</button>
+		<button id="softNavToBar">soft nav to /bar</button>
+		<button id="hardNavToBaz">hard nav to /bar</button>
+		<button id="reload">location.reload()</button>
 		<script>
 			function rerenderLocationHref() {
 				document.getElementById('href').textContent = window.location.href;
@@ -22,11 +24,17 @@
 				document.getElementById('popstate').textContent = ++popstateCount;
 			});
 
-			document.querySelector('button#foo').addEventListener('click', () => {
+			document.querySelector('button#softNavToFoo').addEventListener('click', () => {
 				history.pushState({}, '', '/foo');
 			});
-			document.querySelector('button#bar').addEventListener('click', () => {
+			document.querySelector('button#softNavToBar').addEventListener('click', () => {
 				history.pushState({}, '', '/bar');
+			});
+			document.querySelector('button#hardNavToBaz').addEventListener('click', () => {
+				location.href = '/baz';
+			});
+			document.querySelector('button#reload').addEventListener('click', () => {
+				location.reload();
 			});
 		</script>
 	</body>

--- a/packages/web-fragments/test/playground/location-and-history/index.html
+++ b/packages/web-fragments/test/playground/location-and-history/index.html
@@ -15,8 +15,10 @@
 			<p>location.href: <span id="mainHref"></span></p>
 			<p>popstate count: <span id="mainPopstate">0</span></p>
 
-			<button id="foo">go to /foo</button>
-			<button id="bar">go to /bar</button>
+			<button id="softNavToFoo">soft nav to /foo</button>
+			<button id="softNavToBar">soft nav to /bar</button>
+			<button id="hardNavToBaz">hard nav to /bar</button>
+			<button id="reload">location.reload()</button>
 		</section>
 		<script>
 			function rerenderLocationHref() {
@@ -30,11 +32,17 @@
 				document.getElementById('mainPopstate').textContent = ++popstateCount;
 			});
 
-			document.querySelector('button#foo').addEventListener('click', () => {
+			document.querySelector('button#softNavToFoo').addEventListener('click', () => {
 				history.pushState({}, '', '/foo');
 			});
-			document.querySelector('button#bar').addEventListener('click', () => {
+			document.querySelector('button#softNavToBar').addEventListener('click', () => {
 				history.pushState({}, '', '/bar');
+			});
+			document.querySelector('button#hardNavToBaz').addEventListener('click', () => {
+				location.href = '/baz';
+			});
+			document.querySelector('button#reload').addEventListener('click', () => {
+				location.reload();
 			});
 		</script>
 

--- a/packages/web-fragments/test/playground/location-and-history/spec.ts
+++ b/packages/web-fragments/test/playground/location-and-history/spec.ts
@@ -15,8 +15,10 @@ let main: {
 	popstateCount: Function;
 	back: Function;
 	forward: Function;
-	goToFooButton: Locator;
-	goToBarButton: Locator;
+	softNavToFooButton: Locator;
+	softNavToBarButton: Locator;
+	hardNavToBazButton: Locator;
+	reloadButton: Locator;
 };
 let bound: {
 	locationHref: Function;
@@ -24,8 +26,10 @@ let bound: {
 	popstateCount: Function;
 	back: Function;
 	forward: Function;
-	goToFooButton: Locator;
-	goToBarButton: Locator;
+	softNavToFooButton: Locator;
+	softNavToBarButton: Locator;
+	hardNavToBazButton: Locator;
+	reloadButton: Locator;
 };
 
 let unbound: {
@@ -34,8 +38,10 @@ let unbound: {
 	popstateCount: Function;
 	back: Function;
 	forward: Function;
-	goToFooButton: Locator;
-	goToBarButton: Locator;
+	softNavToFooButton: Locator;
+	softNavToBarButton: Locator;
+	hardNavToBazButton: Locator;
+	reloadButton: Locator;
 };
 
 beforeEach(async ({ page, browserName }) => {
@@ -56,8 +62,10 @@ beforeEach(async ({ page, browserName }) => {
 		popstateCount: async () => await page.locator('#mainPopstate').textContent(),
 		back: () => page.evaluate(() => history.back()),
 		forward: () => page.evaluate(() => history.forward()),
-		goToFooButton: mainSection.locator('button').getByText('go to /foo'),
-		goToBarButton: mainSection.locator('button').getByText('go to /bar'),
+		softNavToFooButton: mainSection.locator('button#softNavToFoo'),
+		softNavToBarButton: mainSection.locator('button#softNavToBar'),
+		hardNavToBazButton: mainSection.locator('button#hardNavToBaz'),
+		reloadButton: mainSection.locator('button#reload'),
 	};
 
 	boundFragment = page.locator('web-fragment[fragment-id="location-and-history"]');
@@ -72,8 +80,10 @@ beforeEach(async ({ page, browserName }) => {
 		popstateCount: () => boundFragment.locator('#popstate').textContent(),
 		back: () => boundContext.evaluate(() => history.back()),
 		forward: () => boundContext.evaluate(() => history.forward()),
-		goToFooButton: boundFragment.locator('button').getByText('go to /foo'),
-		goToBarButton: boundFragment.locator('button').getByText('go to /bar'),
+		softNavToFooButton: boundFragment.locator('button#softNavToFoo'),
+		softNavToBarButton: boundFragment.locator('button#softNavToBar'),
+		hardNavToBazButton: boundFragment.locator('button#hardNavToBaz'),
+		reloadButton: boundFragment.locator('button#reload'),
 	};
 
 	unbound = {
@@ -82,8 +92,10 @@ beforeEach(async ({ page, browserName }) => {
 		popstateCount: () => unboundFragment.locator('#popstate').textContent(),
 		back: () => unboundContext.evaluate(() => history.back()),
 		forward: () => unboundContext.evaluate(() => history.forward()),
-		goToFooButton: unboundFragment.locator('button').getByText('go to /foo'),
-		goToBarButton: unboundFragment.locator('button').getByText('go to /bar'),
+		softNavToFooButton: unboundFragment.locator('button#softNavToFoo'),
+		softNavToBarButton: unboundFragment.locator('button#softNavToBar'),
+		hardNavToBazButton: unboundFragment.locator('button#hardNavToBaz'),
+		reloadButton: unboundFragment.locator('button#reload'),
 	};
 });
 
@@ -104,8 +116,8 @@ test('location.href initialization', async ({ page }) => {
 });
 
 test('changing main location.href should only impact the main frame and bound fragment', async () => {
-	// go to /foo
-	await main.goToFooButton.click();
+	// soft nav to /foo
+	await main.softNavToFooButton.click();
 	expect(await main.locationHref()).toMatch(/http:\/\/localhost:\d+\/foo/);
 	expect(await unbound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\/unbound/);
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/foo/);
@@ -114,8 +126,8 @@ test('changing main location.href should only impact the main frame and bound fr
 	expect(await bound.popstateCount()).toBe('1');
 	expect(await unbound.popstateCount()).toBe('0');
 
-	// go to /bar
-	await main.goToBarButton.click();
+	// soft nav to /bar
+	await main.softNavToBarButton.click();
 	expect(await main.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
 	expect(await unbound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\/unbound/);
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
@@ -125,8 +137,8 @@ test('changing main location.href should only impact the main frame and bound fr
 });
 
 test('changing location.href from a bound fragment should only impact the main frame and bound fragment', async () => {
-	// go to /foo
-	await bound.goToFooButton.click();
+	// soft nav to /foo
+	await bound.softNavToFooButton.click();
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/foo/);
 	expect(await unbound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\/unbound/);
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/foo/);
@@ -135,8 +147,8 @@ test('changing location.href from a bound fragment should only impact the main f
 	expect(await bound.popstateCount()).toBe('0');
 	expect(await unbound.popstateCount()).toBe('0');
 
-	// go to /bar
-	await bound.goToBarButton.click();
+	// soft nav to /bar
+	await bound.softNavToBarButton.click();
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
 	expect(await unbound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\/unbound/);
 	expect(await main.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
@@ -146,14 +158,14 @@ test('changing location.href from a bound fragment should only impact the main f
 });
 
 test('changing unbound location.href should only impact itself and not other fragments or main', async () => {
-	// go to /foo
-	await unbound.goToFooButton.click();
+	// soft nav to /foo
+	await unbound.softNavToFooButton.click();
 	expect(await unbound.locationHref()).toMatch(/http:\/\/localhost:\d+\/foo/);
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
 
-	// go to /bar
-	await unbound.goToBarButton.click();
+	// soft nav to /bar
+	await unbound.softNavToBarButton.click();
 	expect(await unbound.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
 	expect(await main.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
@@ -162,8 +174,8 @@ test('changing unbound location.href should only impact itself and not other fra
 test('back and forward via browser buttons or history.forward()/.back() should work correctly after navigation in the main context', async ({
 	page,
 }) => {
-	await main.goToFooButton.click();
-	await main.goToBarButton.click();
+	await main.softNavToFooButton.click();
+	await main.softNavToBarButton.click();
 
 	expect(await main.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
@@ -193,8 +205,8 @@ test('back and forward via browser buttons or history.forward()/.back() should w
 test('back and forward via browser buttons or history.forward()/.back() should work correctly after navigation in a bound fragment', async ({
 	page,
 }) => {
-	await bound.goToFooButton.click();
-	await bound.goToBarButton.click();
+	await bound.softNavToFooButton.click();
+	await bound.softNavToBarButton.click();
 
 	expect(await main.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
@@ -234,8 +246,8 @@ test('back and forward via browser buttons or history.forward()/.back() should w
 test('history.forward()/.back() in a unbound fragment should update location and history within the fragment only', async ({
 	page,
 }) => {
-	await unbound.goToFooButton.click();
-	await unbound.goToBarButton.click();
+	await unbound.softNavToFooButton.click();
+	await unbound.softNavToBarButton.click();
 
 	expect(await main.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
 	expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
@@ -282,7 +294,7 @@ test('unbound fragment should not participate in history management', async ({ p
 	expect(await unbound.historyLength()).toBe(1);
 
 	await step('unbound fragment can still pushState and replaceState to enable internal routing', async () => {
-		await unbound.goToFooButton.click();
+		await unbound.softNavToFooButton.click();
 
 		// should not add history records to the main history
 		expect(await main.historyLength()).toBe(2);
@@ -292,7 +304,7 @@ test('unbound fragment should not participate in history management', async ({ p
 		expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
 		expect(await unbound.locationHref()).toMatch(/http:\/\/localhost:\d+\/foo/);
 
-		await unbound.goToBarButton.click();
+		await unbound.softNavToBarButton.click();
 		expect(await main.historyLength()).toBe(2);
 		expect(await unbound.historyLength()).toBe(3);
 		expect(await main.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
@@ -307,7 +319,7 @@ test('unbound fragment should not participate in history management', async ({ p
 		expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
 		expect(await unbound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\/unbound/);
 
-		await unbound.goToBarButton.click();
+		await unbound.softNavToBarButton.click();
 		expect(await main.historyLength()).toBe(2);
 		// we dropped one history record because the history has been forked and rewritten by the last navigation to /bar
 		expect(await unbound.historyLength()).toBe(2);
@@ -317,14 +329,14 @@ test('unbound fragment should not participate in history management', async ({ p
 	});
 
 	await step('browser back and forward buttons should not affect unbound fragments', async () => {
-		await bound.goToFooButton.click();
+		await bound.softNavToFooButton.click();
 		expect(await main.historyLength()).toBe(3);
 		expect(await bound.historyLength()).toBe(3);
 		expect(await unbound.historyLength()).toBe(2);
 		expect(await main.locationHref()).toMatch(/http:\/\/localhost:\d+\/foo/);
 		expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/foo/);
 		expect(await unbound.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
-		await unbound.goToBarButton.click();
+		await unbound.softNavToBarButton.click();
 		expect(await main.historyLength()).toBe(3);
 		expect(await bound.historyLength()).toBe(3);
 		expect(await unbound.historyLength()).toBe(3);
@@ -337,5 +349,43 @@ test('unbound fragment should not participate in history management', async ({ p
 		expect(await main.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
 		expect(await bound.locationHref()).toMatch(/http:\/\/localhost:\d+\/location-and-history\//);
 		expect(await unbound.locationHref()).toMatch(/http:\/\/localhost:\d+\/bar/);
+	});
+});
+
+test('hard nav and reload behavior in a bound fragment', async ({ page }) => {
+	// cause some navigations so that we update state and can verify that we actually reloaded
+	await bound.softNavToFooButton.click();
+	await main.back();
+	expect(await main.popstateCount()).toBe('2');
+
+	bound.reloadButton.click();
+	await page.waitForEvent('load', {
+		predicate: (page) => {
+			expect(page.url()).toMatch(/location-and-history\/$/);
+			return true;
+		},
+	});
+
+	// popstateCount is now 0 because we reloaded
+	expect(await main.popstateCount()).toBe('0');
+
+	page.context().route('/baz', (route) => {
+		return route.fulfill({ body: 'baz' });
+	});
+
+	bound.hardNavToBazButton.click();
+	await page.waitForEvent('load', {
+		predicate: (page) => {
+			expect(page.url()).toMatch(/baz$/);
+			return true;
+		},
+	});
+
+	page.goBack();
+	await page.waitForEvent('load', {
+		predicate: (page) => {
+			expect(page.url()).toMatch(/location-and-history\/$/);
+			return true;
+		},
 	});
 });

--- a/packages/web-fragments/test/playground/location-and-history/unbound.html
+++ b/packages/web-fragments/test/playground/location-and-history/unbound.html
@@ -6,13 +6,15 @@
 	</head>
 	<body>
 		<h2>unbound fragment</h2>
-		<p>location.href: <span></span></p>
+		<p>location.href: <span id="href"></span></p>
 		<p>popstate count: <span id="popstate">0</span></p>
-		<button id="foo">go to /foo</button>
-		<button id="bar">go to /bar</button>
+		<button id="softNavToFoo">soft nav to /foo</button>
+		<button id="softNavToBar">soft nav to /bar</button>
+		<button id="hardNavToBaz">hard nav to /bar</button>
+		<button id="reload">location.reload()</button>
 		<script>
 			function rerenderLocationHref() {
-				document.querySelector('span').textContent = window.location.href;
+				document.getElementById('href').textContent = window.location.href;
 			}
 
 			setInterval(rerenderLocationHref, 100);
@@ -22,11 +24,17 @@
 				document.getElementById('popstate').textContent = ++popstateCount;
 			});
 
-			document.querySelector('button#foo').addEventListener('click', () => {
+			document.querySelector('button#softNavToFoo').addEventListener('click', () => {
 				history.pushState({}, '', '/foo');
 			});
-			document.querySelector('button#bar').addEventListener('click', () => {
+			document.querySelector('button#softNavToBar').addEventListener('click', () => {
 				history.pushState({}, '', '/bar');
+			});
+			document.querySelector('button#hardNavToBaz').addEventListener('click', () => {
+				location.href = '/baz';
+			});
+			document.querySelector('button#reload').addEventListener('click', () => {
+				location.reload();
 			});
 		</script>
 	</body>


### PR DESCRIPTION
Previously a hard navigation (`location.href = '/new-url'`) or location reload (`location.reload()`) within a (bound) fragment would result in this fragment getting into a broken state.

The root cause was that navigation would cause the reframed iframe reloaded, unloading all JS code but the DOM remained unchanged.

This resulted in broken UX.

With this change any hard navigation or reload within a bound fragment will be propagated to the main window, causing a hard navigation or reload in the app shell.

It's a bit unclear what should happen when this kind of navigation happens in an unbound fragment. For this reasons, we only empty the fragment DOM for now and log a warning.

This PR is a different take on #112 (the main difference being that we detect the reload much earlier and prevent double reframing which was happening in #112) and includes tests.