### PR TITLE
fix(gateway): disable conditional http requests when fetching a fragment to pierce

### DIFF
--- a/.changeset/dull-jars-hunt.md
+++ b/.changeset/dull-jars-hunt.md
@@ -1,0 +1,11 @@
+---
+'web-fragments': patch
+---
+
+fix(gateway): disable conditional http requests when fetching a fragment to pierce
+
+When piercing, we always need the fragment to return a response body.
+
+For this reason we must disable conditional http requests when piercing by not relaying if-none-match and if-modified-since headers to the fragment endpoint.
+
+This change also contains a small change to the node adapter, so that it doesn't crash when it encounters a 304 response from the shell.

--- a/packages/web-fragments/src/gateway/middleware/web-to-node-adapter.ts
+++ b/packages/web-fragments/src/gateway/middleware/web-to-node-adapter.ts
@@ -246,7 +246,15 @@ function nodeToWebResponse(
 		callNodeNextPromise,
 	);
 
-	let originResponsePromise = originResponse.head.then((head) => new Response(originResponse.body, head));
+	let originResponsePromise = originResponse.head.then((head) => {
+		const originStatus = head.status;
+		const body =
+			(originStatus && originStatus < 200) || originStatus === 204 || originStatus === 205 || originStatus === 304
+				? null
+				: originResponse.body;
+
+		return new Response(body, head);
+	});
 
 	const sendResponse = async (response: Response) => {
 		response.headers.forEach((value, name) => {

--- a/packages/web-fragments/src/gateway/middleware/web.ts
+++ b/packages/web-fragments/src/gateway/middleware/web.ts
@@ -184,6 +184,13 @@ export function getWebMiddleware(
 		const { endpoint } = fragmentConfig;
 		const requestUrl = new URL(originalRequest.url);
 		const fragmentEndpoint = new URL(`${requestUrl.pathname}${requestUrl.search}`, endpoint);
+		const fetchingToPierce = originalRequest.headers.get('sec-fetch-dest') === 'document';
+
+		// if we are about to pierce a fragment, drop headers that apply only to the overall document request
+		if (fetchingToPierce) {
+			originalRequest.headers.delete('if-none-match');
+			originalRequest.headers.delete('if-modified-since');
+		}
 
 		// TODO: add timeout handling
 		//const abortController = new AbortController();


### PR DESCRIPTION
When piercing, we always need the fragment to return a response body.

For this reason we must disable conditional http requests when piercing by not relaying if-none-match and if-modified-since headers to the fragment endpoint.

This change also contains a small change to the node adapter, so that it doesn't crash when it encounters a 304 response from the shell.