### PR TITLE
feat: replace prePiercingStyles and prePiercingClassNames with piercing* names

### DIFF
--- a/.changeset/pretty-doors-guess.md
+++ b/.changeset/pretty-doors-guess.md
@@ -1,0 +1,11 @@
+---
+'web-fragments': patch
+---
+
+feat: replace prePiercingStyles and prePiercingClassNames with ¨piercing¨ prefix
+
+These APIs were originally misnamed, so this change corrects it.
+
+Piercing is the process of inserting a fragment into the initial payload, and there isn´t such thing as "prepiercing" stage in the fragment´s lifecycle.
+
+The change was made a backwards compatible way.

--- a/e2e/node-servers/app/server/src/connect.ts
+++ b/e2e/node-servers/app/server/src/connect.ts
@@ -11,7 +11,7 @@ const PORT = process.env.PORT || 3006;
 
 // Initialize the FragmentGateway
 const gateway = new FragmentGateway({
-    prePiercingStyles: `
+    piercingStyles: `
       <style id="fragment-piercing-styles" type="text/css">
         web-fragment-host[data-piercing="true"] {
           position: absolute;
@@ -31,7 +31,7 @@ const gateway = new FragmentGateway({
 // Register fragments
 gateway.registerFragment({
     fragmentId: 'remix',
-    prePiercingClassNames: ['remix'],
+    piercingClassNames: ['remix'],
     routePatterns: ['/remix-page/:_*', '/_fragment/remix/:_*'],
     endpoint: 'http://localhost:3000',
     onSsrFetchError: () => ({
@@ -43,7 +43,7 @@ gateway.registerFragment({
 
 gateway.registerFragment({
     fragmentId: 'qwik',
-    prePiercingClassNames: ['qwik'],
+    piercingClassNames: ['qwik'],
     routePatterns: ['/qwik-page/:_*', '/_fragment/qwik/:_*'],
     endpoint: 'http://localhost:8123',
     forwardFragmentHeaders: ['x-fragment-name'],

--- a/e2e/node-servers/app/server/src/express.ts
+++ b/e2e/node-servers/app/server/src/express.ts
@@ -12,7 +12,7 @@ const distPath = path.resolve('dist');
 
 // Initialize the FragmentGateway
 const gateway = new FragmentGateway({
-    prePiercingStyles: `
+    piercingStyles: `
       <style id="fragment-piercing-styles" type="text/css">
         web-fragment-host[data-piercing="true"] {
           position: absolute;

--- a/e2e/pierced-react/functions/_middleware.ts
+++ b/e2e/pierced-react/functions/_middleware.ts
@@ -3,7 +3,7 @@ import { PagesFunction } from '@cloudflare/workers-types';
 
 // Initialize the FragmentGateway
 const gateway = new FragmentGateway({
-	prePiercingStyles: `<style id="fragment-piercing-styles" type="text/css">
+	piercingStyles: `<style id="fragment-piercing-styles" type="text/css">
     web-fragment-host[data-piercing="true"] {
       position: absolute;
       z-index: 9999999999999999999999999999999;
@@ -14,7 +14,7 @@ const gateway = new FragmentGateway({
 // Register fragments
 gateway.registerFragment({
 	fragmentId: 'remix',
-	prePiercingClassNames: ['remix'],
+	piercingClassNames: ['remix'],
 	routePatterns: ['/remix-page/:_*', '/_fragment/remix/:_*'],
 	endpoint: 'http://localhost:3000',
 	onSsrFetchError: () => ({
@@ -26,7 +26,7 @@ gateway.registerFragment({
 
 gateway.registerFragment({
 	fragmentId: 'qwik',
-	prePiercingClassNames: ['qwik'],
+	piercingClassNames: ['qwik'],
 	routePatterns: ['/qwik-page/:_*', '/_fragment/qwik/:_*'],
 	endpoint: 'http://localhost:8123',
 	forwardFragmentHeaders: ['x-fragment-name'],

--- a/packages/web-fragments/src/gateway/fragment-gateway.ts
+++ b/packages/web-fragments/src/gateway/fragment-gateway.ts
@@ -3,14 +3,22 @@ import { MatchFunction, match } from 'path-to-regexp';
 export class FragmentGateway {
 	private fragmentConfigs: Map<string, FragmentConfig> = new Map();
 	private routeMap: Map<MatchFunction, FragmentConfig> = new Map();
-	#prePiercingStyles: string;
+	#piercingStyles?: string;
 
 	constructor(config?: FragmentGatewayConfig) {
-		this.#prePiercingStyles = config?.prePiercingStyles ?? '';
+		if (config?.prePiercingStyles) {
+			this.#piercingStyles = config.prePiercingStyles;
+			console.warn(
+				"\x1b[31m You're using the deprecated `prePiercingStyles` property" +
+					` in the fragment gateway config. Please use \`piercingStyles\` instead. \x1b[0m`,
+			);
+		} else {
+			this.#piercingStyles = config?.piercingStyles ?? '';
+		}
 	}
 
-	get prePiercingStyles() {
-		return this.#prePiercingStyles;
+	get piercingStyles() {
+		return this.#piercingStyles;
 	}
 
 	/**
@@ -91,7 +99,12 @@ export interface FragmentConfig {
 	 * For best results they should use the following selector:
 	 * :not(web-fragment) > web-fragment-host[fragment-id="fragmentId"]
 	 */
-	prePiercingClassNames: string[];
+	piercingClassNames?: string[];
+	/**
+	 * @deprecated use `piercingClassNames` instead
+	 *
+	 */
+	prePiercingClassNames?: string[];
 	/**
 	 * An array of route patterns this fragment should handle serving.
 	 * Pattern format must adhere to https://github.com/pillarjs/path-to-regexp#parameters syntax
@@ -131,6 +144,10 @@ export interface SSRFetchErrorResponse {
 }
 
 export interface FragmentGatewayConfig {
+	piercingStyles?: string;
+	/**
+	 * @deprecated use `piercingStyles` instead
+	 */
 	prePiercingStyles?: string;
 }
 

--- a/packages/web-fragments/src/gateway/middleware/readme.md
+++ b/packages/web-fragments/src/gateway/middleware/readme.md
@@ -14,7 +14,7 @@ Initialize the gateway and register the fragments
 import { FragmentGateway, getStandardMiddleware } from 'web-fragments/gateway';
 // Initialize the FragmentGateway
 const gateway = new FragmentGateway({
-	prePiercingStyles: `<style id="fragment-piercing-styles" type="text/css">
+	piercingStyles: `<style id="fragment-piercing-styles" type="text/css">
     web-fragment-host[data-piercing="true"] {
       position: absolute;
       z-index: 9999999999999999999999999999999;
@@ -25,7 +25,7 @@ const gateway = new FragmentGateway({
 // Register fragments
 gateway.registerFragment({
 	fragmentId: 'remix',
-	prePiercingClassNames: ['remix'],
+	piercingClassNames: ['remix'],
 	routePatterns: ['/remix-page/:_*', '/_fragment/remix/:_*'],
 	endpoint: 'http://localhost:3000',
 	onSsrFetchError: () => ({
@@ -66,7 +66,7 @@ const port = 3000;
 
 // Initialize the FragmentGateway
 const gateway = new FragmentGateway({
-	prePiercingStyles: `<style id="fragment-piercing-styles" type="text/css">
+	piercingStyles: `<style id="fragment-piercing-styles" type="text/css">
         web-fragment-host[data-piercing="true"] {
             position: absolute;
             z-index: 9999999999999999999999999999999;
@@ -77,7 +77,7 @@ const gateway = new FragmentGateway({
 // Register fragments
 gateway.registerFragment({
 	fragmentId: 'example-fragment',
-	prePiercingClassNames: ['example-class'],
+	piercingClassNames: ['example-class'],
 	routePatterns: ['/example-path', '/_fragment/example-path'],
 	endpoint: 'http://localhost:3001',
 	onSsrFetchError: () => ({

--- a/packages/web-fragments/src/gateway/middleware/web.ts
+++ b/packages/web-fragments/src/gateway/middleware/web.ts
@@ -251,7 +251,7 @@ export function getWebMiddleware(
 		fragmentConfig: FragmentConfig;
 		gateway: FragmentGatewayConfig;
 	}) {
-		const { fragmentId, prePiercingClassNames } = fragmentConfig;
+		const { fragmentId, piercingClassNames = [] } = fragmentConfig;
 
 		// Native HTMLRewriter now supports appending/merging of streams directly, so we don't need to block the rewriting
 		// until we have the full fragment content. This improves performance.
@@ -262,14 +262,14 @@ export function getWebMiddleware(
 			return new HTMLRewriter()
 				.on('head', {
 					element(element) {
-						element.append(gateway.prePiercingStyles ?? '', { html: true });
+						element.append(gateway.piercingStyles ?? '', { html: true });
 					},
 				})
 				.on('body', {
 					async element(element) {
 						(element.append as any as (content: ReadableStream, options: { html: boolean }) => void)(
 							asReadableStream`
-								<web-fragment-host class="${prePiercingClassNames.join(' ')}" fragment-id="${fragmentId}" data-piercing="true">
+								<web-fragment-host class="${piercingClassNames.join(' ')}" fragment-id="${fragmentId}" data-piercing="true">
 									<template shadowrootmode="open">${fragmentResponse.body ?? ''}</template>
 								</web-fragment-host>`,
 							{ html: true },
@@ -283,13 +283,13 @@ export function getWebMiddleware(
 			return new HTMLRewriter()
 				.on('head', {
 					element(element) {
-						element.append(gateway.prePiercingStyles ?? '', { html: true });
+						element.append(gateway.piercingStyles ?? '', { html: true });
 					},
 				})
 				.on('body', {
 					element(element) {
 						element.append(
-							`<web-fragment-host class="${prePiercingClassNames.join(' ')}" fragment-id="${fragmentId}" data-piercing="true"><template shadowrootmode="open">${fragmentContent}</template></web-fragment-host>`,
+							`<web-fragment-host class="${piercingClassNames.join(' ')}" fragment-id="${fragmentId}" data-piercing="true"><template shadowrootmode="open">${fragmentContent}</template></web-fragment-host>`,
 							{ html: true },
 						);
 					},

--- a/packages/web-fragments/test/gateway/gateway.spec.ts
+++ b/packages/web-fragments/test/gateway/gateway.spec.ts
@@ -646,7 +646,7 @@ for (const environment of environments) {
 
 			fragmentGateway.registerFragment({
 				fragmentId: 'fragmentFoo',
-				prePiercingClassNames: ['foo'],
+				piercingClassNames: ['foo'],
 				routePatterns: ['/foo/:_*', '/_fragment/foo/:_*'],
 				endpoint: 'http://foo.test:1234',
 				upstream: 'http://foo.test:1234',
@@ -654,7 +654,7 @@ for (const environment of environments) {
 
 			fragmentGateway.registerFragment({
 				fragmentId: 'fragmentBar',
-				prePiercingClassNames: ['bar'],
+				piercingClassNames: ['bar'],
 				routePatterns: ['/bar/:_*', '/_fragment/bar/:_*'],
 				endpoint: 'http://bar.test:4321',
 				upstream: 'http://bar.test:4321',
@@ -674,7 +674,7 @@ for (const environment of environments) {
 			fragmentGateway.registerFragment({
 				fragmentId: 'unpiercedFragment',
 				piercing: false,
-				prePiercingClassNames: [],
+				piercingClassNames: [],
 				routePatterns: ['/unpierced/:_*', '/_fragment/unpierced/:_*'],
 				endpoint: 'http://unpierced.test:1234',
 				upstream: 'http://unpierced.test:1234',


### PR DESCRIPTION
These APIs were originally misnamed, so this change corrects it.

Piercing is the process of inserting a fragment into the initial payload, and there isn´t such thing as "prepiercing" stage in the fragment´s lifecycle.

The change was made a backwards compatible way.