### PR TITLE
dev: fix pnpm test-debug:gateway script

### DIFF
--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -46,7 +46,7 @@
 		"test:unit": "pnpm vitest run src",
 		"test:gateway": "pnpm -C test/gateway test",
 		"test:playground": "pnpm -C test/playground test",
-		"test-debug:gateway": "vitest test/gateway --test-timeout=0 --no-file-parallelism",
+		"test-debug:gateway": "pnpm -C test/gateway test-debug",
 		"changeset": "pnpm -C ../../ exec changeset",
 		"prepare": "pnpm build"
 	},

--- a/packages/web-fragments/test/gateway/package.json
+++ b/packages/web-fragments/test/gateway/package.json
@@ -3,7 +3,8 @@
 	"name": "wf-gateway-tests",
 	"type": "module",
 	"scripts": {
-		"test": "vitest"
+		"test": "vitest",
+		"test-debug": "vitest --test-timeout=0 --no-file-parallelism"
 	},
 	"devDependencies": {
 		"@types/connect": "^3.4.38",


### PR DESCRIPTION
Previously the setup.ts script didn't run which caused runtime errors when test-debug:gateway was started.