### PR TITLE
fix (reframed): fix inert scripts being incorrectly evaluated on insertion

### DIFF
--- a/.changeset/tidy-feet-learn.md
+++ b/.changeset/tidy-feet-learn.md
@@ -1,0 +1,5 @@
+---
+'web-fragments': patch
+---
+
+Fix inert scripts being incorrectly evaluated multiple times on DOM insertion

--- a/packages/web-fragments/test/playground/index.html
+++ b/packages/web-fragments/test/playground/index.html
@@ -25,6 +25,7 @@
 				<a href="/script-isolation/">/script-isolation/</a> (<a href="/script-isolation/fragment-a">fragment a</a>,
 				<a href="/script-isolation/fragment-b">fragment b</a>)
 			</li>
+			<li><a href="/script-insertion/">/script-insertion/</a> (<a href="/script-insertion/fragment">fragment</a>)</li>
 			<li>
 				<a href="/location-and-history/">/location-and-history/</a> (<a href="/location-and-history/fragment"
 					>fragment</a

--- a/packages/web-fragments/test/playground/script-insertion/index.html
+++ b/packages/web-fragments/test/playground/script-insertion/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+	<head>
+		<script type="module">
+			import { initializeWebFragments } from 'web-fragments';
+			initializeWebFragments();
+		</script>
+	</head>
+	<body>
+		<h1>WF Playground: Inert script evaluation</h1>
+
+		<web-fragment-host fragment-id="script-insertion">
+			<template shadowrootmode="open">
+				<wf-html>
+					<wf-head>
+						<style>
+							#script-execution-count {
+								text-decoration: underline;
+								font-weight: 600;
+							}
+
+							.assertion-container {
+								display: flex;
+								align-items: center;
+								gap: 4px;
+								margin: 8px 0;
+							}
+						</style>
+					</wf-head>
+					<wf-body>
+						<section id="reference-node">
+							<div>Counter script executed <span id="script-execution-count">0</span> times</div>
+							<div class="assertion-container">
+								<p>Counter script executed only 1 time:</p>
+								<input id="script-counter-checkbox" type="checkbox" />
+							</div>
+						</section>
+						<script id="counter-script" type="inert">
+							if (window.scriptExecutionCount) {
+								window.scriptExecutionCount++;
+							} else {
+								window.scriptExecutionCount = 1;
+							}
+							document.getElementById('script-execution-count').textContent = window.scriptExecutionCount;
+						</script>
+						<script type="inert">
+							const counterScript = document.getElementById('counter-script');
+							const referenceNode = document.getElementById('reference-node');
+							document.body.insertBefore(counterScript, referenceNode);
+							document.body.appendChild(counterScript);
+							document.body.appendChild(counterScript);
+							document.body.appendChild(counterScript);
+						</script>
+
+						<script type="inert">
+							if (window.scriptExecutionCount === 1) {
+								document.getElementById('script-counter-checkbox').checked = true;
+							}
+						</script>
+					</wf-body>
+				</wf-html>
+			</template>
+		</web-fragment-host>
+	</body>
+</html>

--- a/packages/web-fragments/test/playground/script-insertion/spec.ts
+++ b/packages/web-fragments/test/playground/script-insertion/spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+const { beforeEach, step } = test;
+import { failOnBrowserErrors } from '../playwright.utils';
+
+beforeEach(failOnBrowserErrors);
+
+test('DOM querying in fragments', async ({ page }) => {
+	await page.goto('/script-insertion/');
+
+	await step('ensure the test harness app loaded', async () => {
+		await expect(page.locator('h1')).toHaveText('WF Playground: Inert script evaluation');
+	});
+
+	const fragment = page.locator('web-fragment-host');
+
+	await step('ensure counter script is only evaluated once', async () => {
+		await expect(fragment.locator('#script-counter-checkbox')).toBeChecked();
+	});
+});


### PR DESCRIPTION
## Overview
Script tags that have already been evaluated and added to the iframe document should not be re-evaluated when a reference to that node is then added to the DOM via another script tag.

Consider this scenario in the fragment application:
![script-insertion-reframed](https://github.com/user-attachments/assets/a03c2083-8558-48cc-8731-529fb70c19df)


Because the `<script id="counter-script" />` element has already been "evaluated" in the iframe document, calling `document.body.appendChild()` on the inert script should be a noop. However, reframed incorrectly adds this script to the iframe (again) because the reference to the inert script in the reframedDOM was never truly evaluated in the reframedDOM.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Testing screenshots
![Screenshot 2025-03-26 at 11 53 59 AM](https://github.com/user-attachments/assets/03694b07-b048-4705-be54-2049eb3d1f9f)

