### PR TITLE
fix (gateway): add support for search params match

### DIFF
--- a/.changeset/olive-toys-doubt.md
+++ b/.changeset/olive-toys-doubt.md
@@ -1,0 +1,5 @@
+---
+'web-fragments': patch
+---
+
+add support for search params pattern matching in the gateway

--- a/.changeset/violet-dogs-tie.md
+++ b/.changeset/violet-dogs-tie.md
@@ -1,0 +1,5 @@
+---
+'web-fragments': patch
+---
+
+fix regression in prepareUnattachedInlineScript() in reframed.ts where empty scripts were not being added to the iframe

--- a/packages/web-fragments/src/elements/reframed/script-execution.ts
+++ b/packages/web-fragments/src/elements/reframed/script-execution.ts
@@ -161,7 +161,8 @@ function prepareUnattachedInlineScript(script: HTMLScriptElement, iframeDocument
 	inertScript.remove();
 	inertScript.firstChild!.remove();
 
-	executeInertScript(inertScript, iframeDocument);
+	execToInertScriptMap.set(execScript, inertScript);
+	getInternalReference(iframeDocument, 'body').appendChild(execScript);
 
 	const origScriptAppendChild = inertScript.appendChild;
 	inertScript.appendChild = function (node) {

--- a/packages/web-fragments/src/elements/reframed/script-execution.ts
+++ b/packages/web-fragments/src/elements/reframed/script-execution.ts
@@ -93,16 +93,36 @@ export function executeInertScript(inertScript: HTMLScriptElement, iframeDocumen
 
 	assert(!!(inertScript.src || inertScript.textContent), `Can't execute script without src or textContent!`);
 
-	const execScript = iframeDocument.importNode(inertScript, true);
-	execToInertScriptMap.set(execScript, inertScript);
+	attachScriptsToIframe({ inertScript, iframeDocument });
+
+	return true;
+}
+
+/**
+ * Attaches exec scripts to iframe and keeps a record of already evaluated scripts
+ * @param inertScript inert script already appended to a document within reframed DOM
+ * @param execScript exec script to be attached to the iframe document.
+ * @param iframeDocument iframe document in which the script should execute.
+ */
+export function attachScriptsToIframe({
+	inertScript,
+	execScript,
+	iframeDocument,
+}: {
+	inertScript: HTMLScriptElement;
+	execScript?: HTMLScriptElement;
+	iframeDocument: Document;
+}) {
+	if (!execScript) {
+		execScript = iframeDocument.importNode(inertScript, true);
+	}
 
 	// the following line will append the executable script to iframe
 	// - inline scripts (script with textContent) will be executed synchronously when attached
 	// - external scripts (with src attribute) will execute once the current turn of the event loop unwinds
+	execToInertScriptMap.set(execScript, inertScript);
 	getInternalReference(iframeDocument, 'body').appendChild(execScript);
 	alreadyExecutedScripts.add(inertScript);
-
-	return true;
 }
 
 /**
@@ -161,8 +181,9 @@ function prepareUnattachedInlineScript(script: HTMLScriptElement, iframeDocument
 	inertScript.remove();
 	inertScript.firstChild!.remove();
 
-	execToInertScriptMap.set(execScript, inertScript);
-	getInternalReference(iframeDocument, 'body').appendChild(execScript);
+	// We have already cloned the inertScript so we don't need to clone it again.
+	// Cloning again will cause the execScript to be neutralized.
+	attachScriptsToIframe({ inertScript, execScript, iframeDocument });
 
 	const origScriptAppendChild = inertScript.appendChild;
 	inertScript.appendChild = function (node) {

--- a/packages/web-fragments/src/gateway/fragment-gateway.spec.ts
+++ b/packages/web-fragments/src/gateway/fragment-gateway.spec.ts
@@ -1,0 +1,70 @@
+import { FragmentGateway } from './fragment-gateway';
+import { describe, test, expect, beforeAll } from 'vitest';
+
+describe('matchRequestToFragment()', () => {
+	const fragmentGateway = new FragmentGateway();
+	fragmentGateway.registerFragment({
+		fragmentId: 'fragment-1',
+		routePatterns: ['/foo/:_*', '/_fragments/foo/:_*', '/__shared?a=a&b=b', '/__shared?param=/:id/foo'],
+		endpoint: 'https://example-fragment.com',
+	});
+	fragmentGateway.registerFragment({
+		fragmentId: 'fragment-2',
+		routePatterns: ['/bar/:_*', '/_fragments/bar/:_*', '/__shared?param=/:id/bar'],
+		endpoint: 'https://example-fragment-bar.com',
+	});
+
+	test('should match fragment-1: /foo/bar', () => {
+		const url = '/foo/bar';
+		const fragment = fragmentGateway.matchRequestToFragment(url);
+		expect(fragment?.fragmentId).toBe('fragment-1');
+	});
+
+	test('should match fragment-1: /_fragments/foo/app.js', () => {
+		const url = '/_fragments/foo/app.js';
+		const fragment = fragmentGateway.matchRequestToFragment(url);
+		expect(fragment?.fragmentId).toBe('fragment-1');
+	});
+
+	test('should match fragment-1: /__shared?param=/hash123/foo', () => {
+		const url = '/__shared?param=%2Fhash123%2Ffoo';
+		const fragment = fragmentGateway.matchRequestToFragment(url);
+		expect(fragment?.fragmentId).toBe('fragment-1');
+	});
+
+	test('should match fragment-1: /__shared?param=/hash123/foo&extra_param=bar', () => {
+		const url = '/__shared?param=%2Fhash123%2Ffoo';
+		const fragment = fragmentGateway.matchRequestToFragment(url);
+		expect(fragment?.fragmentId).toBe('fragment-1');
+	});
+
+	test('should match fragment-1: /__shared?a=a&b=b', () => {
+		const url = '/__shared?a=a&b=b';
+		const fragment = fragmentGateway.matchRequestToFragment(url);
+		expect(fragment?.fragmentId).toBe('fragment-1');
+	});
+
+	test('should match fragment-2: /__shared?param=/hash123/bar', () => {
+		const url = '/__shared?param=%2Fhash123%2Fbar';
+		const fragment = fragmentGateway.matchRequestToFragment(url);
+		expect(fragment?.fragmentId).toBe('fragment-2');
+	});
+
+	test('should fail to match any fragment: /baz', () => {
+		const url = '/baz';
+		const fragment = fragmentGateway.matchRequestToFragment(url);
+		expect(fragment).not.toBeTruthy();
+	});
+
+	test('should fail to match any fragment: /__shared', () => {
+		const url = '/__shared';
+		const fragment = fragmentGateway.matchRequestToFragment(url);
+		expect(fragment).not.toBeTruthy();
+	});
+
+	test('should fail to match any fragment: /__shared?a=a', () => {
+		const url = '/__shared?a=a';
+		const fragment = fragmentGateway.matchRequestToFragment(url);
+		expect(fragment).not.toBeTruthy();
+	});
+});

--- a/packages/web-fragments/src/gateway/fragment-gateway.ts
+++ b/packages/web-fragments/src/gateway/fragment-gateway.ts
@@ -82,8 +82,9 @@ export class FragmentGateway {
 				return true;
 			};
 
-			const matcher = (urlPath: string) => {
-				const [pathname, search = ''] = urlPath.split('?');
+			// The url parameter is only the pathname and search param (i.e /foo?search=value)
+			const matcher = (url: string) => {
+				const [pathname, search = ''] = url.split('?');
 				return pathMatcher(pathname) && searchMatcher(search);
 			};
 

--- a/packages/web-fragments/src/gateway/middleware/web.ts
+++ b/packages/web-fragments/src/gateway/middleware/web.ts
@@ -20,7 +20,8 @@ export function getWebMiddleware(
 	const { additionalHeaders = {}, mode = 'development' }: FragmentMiddlewareOptions = options;
 
 	return async (request: Request, next: () => Promise<Response>): Promise<Response> => {
-		const matchedFragment = gateway.matchRequestToFragment(new URL(request.url).pathname);
+		const { pathname, search = '' } = new URL(request.url);
+		const matchedFragment = gateway.matchRequestToFragment(`${pathname}${search}`);
 
 		/**
 		 * Handle app shell (legacy app) requests

--- a/packages/web-fragments/test/playground/script-insertion/index.html
+++ b/packages/web-fragments/test/playground/script-insertion/index.html
@@ -35,6 +35,7 @@
 								<input id="script-counter-checkbox" type="checkbox" />
 							</div>
 						</section>
+
 						<script id="counter-script" type="inert">
 							if (window.scriptExecutionCount) {
 								window.scriptExecutionCount++;
@@ -43,16 +44,19 @@
 							}
 							document.getElementById('script-execution-count').textContent = window.scriptExecutionCount;
 						</script>
-						<script type="inert">
+
+						<script id="script-insertion" type="inert">
 							const counterScript = document.getElementById('counter-script');
 							const referenceNode = document.getElementById('reference-node');
+
+							counterScript.remove();
+							document.body.appendChild(counterScript);
+
+							counterScript.remove();
 							document.body.insertBefore(counterScript, referenceNode);
-							document.body.appendChild(counterScript);
-							document.body.appendChild(counterScript);
-							document.body.appendChild(counterScript);
 						</script>
 
-						<script type="inert">
+						<script id="script-assertion" type="inert">
 							if (window.scriptExecutionCount === 1) {
 								document.getElementById('script-counter-checkbox').checked = true;
 							}


### PR DESCRIPTION
## Overview
Sometimes, fragments are hosted on the same root pathname but can be differentiated by specific search param patterns. For example, `react-router` makes requests to `/__manifest?p=/path/to/route`. Currently, the gateway has no mechanism for matching against a search parameter pattern, only a pathname.

This PR adds search param matching as a non-breaking change by using `path-to-regexp` to support the same matching syntax used for pathname matching.

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```

## Testing screenshots
![Screenshot 2025-03-28 at 3 06 17 PM](https://github.com/user-attachments/assets/dc0d32b5-4334-4a9d-b7e0-ee53dfa2f8b4)

