### PR TITLE
feat: make it possible to register a fragment endpoint as a fetcher function

### DIFF
--- a/.changeset/brown-penguins-serve.md
+++ b/.changeset/brown-penguins-serve.md
@@ -1,0 +1,10 @@
+---
+'web-fragments': patch
+---
+
+feat: make it possible to register a fragment endpoint as a fetcher function
+
+Fragments can now be registered using a url or function that matches the standard Fetch API.
+
+This enables more flexibility when connecting to fragment endpoints.
+On Cloudflare specifically this means that a gateway can connect to a fragment using a service binding.

--- a/packages/web-fragments/src/gateway/fragment-gateway.ts
+++ b/packages/web-fragments/src/gateway/fragment-gateway.ts
@@ -141,10 +141,10 @@ export interface FragmentConfig {
 	 */
 	routePatterns: string[];
 	/**
-	 * The endpoint URI of the fragment application.
+	 * The endpoint URL of the fragment application, or a `fetch` function compatible with the standard [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 	 * This will be fetched on any request paths matching the specified `routePatterns`
 	 */
-	endpoint: string;
+	endpoint: string | typeof fetch;
 	/**
 	 * @deprecated use `endpoint` instead
 	 */


### PR DESCRIPTION
Fragments can now be registered using a url or function that matches the standard Fetch API.

This enables more flexibility when connecting to fragment endpoints. On Cloudflare specifically this means that a gateway can connect to a fragment using a service binding.

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```
