### PR TITLE
docs: update README wrong quote header

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Web Fragments are a radically new approach to Web micro-frontends which is frame
 
 New to micro-frontends? Check out https://microfrontend.dev
 
-> [!NOTE] The project is in beta, but is already being used in production by teams at [Cloudflare](https://www.cloudflare.com/).
+> [!NOTE]
+> The project is in beta, but is already being used in production by teams at [Cloudflare](https://www.cloudflare.com/).
 > We are looking for teams and companies interested in providing early feedback that can help us shape the feature set and APIs.
 
 ## The goal


### PR DESCRIPTION
This only fixes the quote in the README to be rendered correctly

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```
