### PR TITLE
fix: don't blow up on unknown elements during event retargeting

### DIFF
--- a/.changeset/slow-shirts-double.md
+++ b/.changeset/slow-shirts-double.md
@@ -1,0 +1,9 @@
+---
+'web-fragments': patch
+---
+
+fix: don't blow up on unknown elements during event retargeting
+
+We noticed that for example view transition pseudo elements can trigger
+a mapping error, which currently throws as a safeguard, but this prevents apps from working.
+So until we figure out how to handle this properly we now just warn rather than throw.

--- a/packages/web-fragments/src/elements/reframed/iframe-patches.ts
+++ b/packages/web-fragments/src/elements/reframed/iframe-patches.ts
@@ -478,7 +478,8 @@ export function initializeIFrameContext(
 			case mainDocument.body:
 				return iframeDocument.body;
 			default:
-				throw new Error('Unknown main context target: ' + target);
+				console.warn('reframed events: Unknown main context target: ', target);
+				return target;
 		}
 	};
 
@@ -493,7 +494,8 @@ export function initializeIFrameContext(
 			case iframeDocument.body:
 				return mainDocument.body;
 			default:
-				throw new Error('Unknown reframed context target: ' + target);
+				console.warn('reframed events: Unknown reframed context target: ', target);
+				return target;
 		}
 	};
 


### PR DESCRIPTION
We noticed that for example view transition pseudo elements can trigger a mapping error, which currently throws as a safeguard, but this prevents apps from working. So until we figure out how to handle this properly we now just warn rather than throw.

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

- ...

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[ ] No
```
