### PR TITLE
fix: throw WebFragmentError when we risk infinite iframe recursion during reframe init

### DIFF
--- a/.changeset/khaki-apricots-run.md
+++ b/.changeset/khaki-apricots-run.md
@@ -1,0 +1,7 @@
+---
+'web-fragments': patch
+---
+
+fix(web-fragments): handle iframe errors due to x-frame-options=deny header more gracefully
+
+We now detect this scenario and show a helpful error in the console.

--- a/.changeset/real-sheep-hammer.md
+++ b/.changeset/real-sheep-hammer.md
@@ -1,0 +1,24 @@
+---
+'web-fragments': minor
+---
+
+feat(gateway): enable fragments to configure their own Content Security Policy (CSP)
+
+With FragmentConfig#iframeHeaders, fragments can now configure their own Content Security Policy (CSP). See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP
+
+This feature is very useful in enabling fragments to make their CSP more strict or relaxed based without requiring the entire fragment federation to have a single CSP policy.
+
+Important: The CSP configured only applies to the script execution and does not affect the DOM operations. In fragments the script execution is isolated, but DOM is shared by all fragments and the host app. This means that the host app should be configured with a CSP that takes into account the DOM needs of all fragments (e.g. `img-src`), but the script execution and mainly allowing/disallowing `unsafe-eval` can be configured at the fragment level.
+
+Example usage:
+
+```js
+fragmentGateway.registerFragment({
+	fragmentId: 'my-fragment',
+  ...
+  iframeHeaders: {
+    'Content-Security-Policy': `connect-src 'self'; object-src 'none'; script-src 'self'; base-uri 'self';`,
+		...
+	},
+});
+```

--- a/.changeset/tasty-parents-kiss.md
+++ b/.changeset/tasty-parents-kiss.md
@@ -1,0 +1,9 @@
+---
+'web-fragments': patch
+---
+
+fix: throw WebFragmentError when we risk infinite iframe recursion during reframe init
+
+If the fragment gateway was not properly configured (e.g. the routePaths don't contain the main navigable url that starts a fragment), reframed creates an iframe which when loaded by the browser loads the original host html rather than the minimal reframed init html, which then causes a new nested fragment to be created which then repeats the process, resulting in an infinite recursion.
+
+This turns out to be a rather common user error, so to make it easier to diagnose and fix, we now detect it and throw an error.

--- a/.changeset/tricky-singers-love.md
+++ b/.changeset/tricky-singers-love.md
@@ -1,0 +1,24 @@
+---
+'web-fragments': minor
+---
+
+feat(gateway): add FragmentConfig#iframeHeaders support for configuring iframe headers
+
+The fragment config can now optionally include `iframeHeaders` key that can contain a `Record<string, string>` of header names and their values.
+
+This feature is useful to configure response headers for requests that come from initialization of the reframed iframe which powers the configured Web Fragment.
+
+For example, you could use this header to configure CSP policy for the iframe, or override any of the default headers set by the Web Fragments gateway.
+
+Example usage:
+
+```js
+fragmentGateway.registerFragment({
+	fragmentId: 'my-fragment',
+  ...
+  iframeHeaders: {
+		'Some-Header': 'my value',
+		'another-header': 'my other value',
+	},
+});
+```

--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -43,6 +43,7 @@
 		"types:root": "tsc -p .",
 		"types:check": "pnpm types --noEmit --emitDeclarationOnly false",
 		"types": "pnpm run --filter web-fragments --parallel \"/^types:(?!check).*/\"",
+		"test": "pnpm test:unit && pnpm test:gateway && pnpm test:playground",
 		"test:unit": "pnpm vitest run src",
 		"test:gateway": "pnpm -C test/gateway test",
 		"test:playground": "pnpm test:playground:pierced && pnpm test:playground:nonpierced",

--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -34,7 +34,7 @@
 		"dist"
 	],
 	"scripts": {
-		"dev": "vite",
+		"dev": "pnpm dev:playground",
 		"dev:playground": "pnpm -C test/playground dev",
 		"preview:playground": "pnpm -C test/playground preview",
 		"build": "pnpm types && vite build",

--- a/packages/web-fragments/src/elements/reframed/reframed.ts
+++ b/packages/web-fragments/src/elements/reframed/reframed.ts
@@ -76,18 +76,6 @@ export function reframed(
 	let alreadyLoaded = false;
 
 	iframe.addEventListener('load', () => {
-		// see web.ts, section "Handle IFrame request from reframed" for more details
-		if (iframe.contentDocument?.title !== 'Web Fragments: reframed') {
-			throw new WebFragmentError(
-				`Reframed IFrame init error!\n` +
-					`IFrame loaded unexpected content from ${iframe.src}!\n` +
-					`Ensure that the Web Fragment gateway contains a fragment registration with "routePatterns" matching path: ${new URL(iframe.src).pathname}` +
-					(!iframe.contentDocument
-						? '\nAdditionally, ensure that the iframe response is not delivered with the "X-Frame-Options" response header set to "deny".'
-						: ''),
-			);
-		}
-
 		if (alreadyLoaded) {
 			// iframe reload detected!
 
@@ -105,6 +93,18 @@ export function reframed(
 			return;
 		}
 		alreadyLoaded = true;
+
+		// see web.ts, section "Handle IFrame request from reframed" for more details
+		if (iframe.contentDocument?.title !== 'Web Fragments: reframed') {
+			throw new WebFragmentError(
+				`Reframed IFrame init error!\n` +
+					`IFrame loaded unexpected content from ${iframe.src}!\n` +
+					`Ensure that the Web Fragment gateway contains a fragment registration with "routePatterns" matching path: ${new URL(iframe.src).pathname}` +
+					(!iframe.contentDocument
+						? '\nAdditionally, ensure that the iframe response is not delivered with the "X-Frame-Options" response header set to "deny".'
+						: ''),
+			);
+		}
 
 		initializeIFrameContext(iframe, reframedShadowRoot, wfDocumentElement, options.bound);
 		resolveIframeReady(iframe);

--- a/packages/web-fragments/src/elements/reframed/reframed.ts
+++ b/packages/web-fragments/src/elements/reframed/reframed.ts
@@ -2,6 +2,7 @@ import WritableDOMStream from 'writable-dom';
 import { initializeIFrameContext } from './iframe-patches';
 import { initializeMainContext } from './main-patches';
 import { executeScriptsInPiercedFragment } from './script-execution';
+import { WebFragmentError } from './utils/web-fragment-error';
 
 type ReframedOptions = {
 	pierced: boolean;
@@ -75,6 +76,12 @@ export function reframed(
 	let alreadyLoaded = false;
 
 	iframe.addEventListener('load', () => {
+		if (iframe.contentDocument?.head.childNodes.length !== 1 && iframe.contentDocument?.body.childNodes.length !== 0) {
+			throw new WebFragmentError(
+				`Reframed IFrame init error!\nIFrame loaded unexpected content from ${iframe.src}!\nEnsure that Web Fragment gateway contains a fragment registration with a path matching: ${new URL(iframe.src).pathname}`,
+			);
+		}
+
 		if (alreadyLoaded) {
 			// iframe reload detected!
 

--- a/packages/web-fragments/src/elements/reframed/reframed.ts
+++ b/packages/web-fragments/src/elements/reframed/reframed.ts
@@ -78,7 +78,12 @@ export function reframed(
 	iframe.addEventListener('load', () => {
 		if (iframe.contentDocument?.head.childNodes.length !== 1 && iframe.contentDocument?.body.childNodes.length !== 0) {
 			throw new WebFragmentError(
-				`Reframed IFrame init error!\nIFrame loaded unexpected content from ${iframe.src}!\nEnsure that Web Fragment gateway contains a fragment registration with a path matching: ${new URL(iframe.src).pathname}`,
+				`Reframed IFrame init error!\n` +
+					`IFrame loaded unexpected content from ${iframe.src}!\n` +
+					`Ensure that the Web Fragment gateway contains a fragment registration with "routePatterns" matching path: ${new URL(iframe.src).pathname}` +
+					(!iframe.contentDocument
+						? '\nAdditionally, ensure that the iframe response is not delivered with the "X-Frame-Options" response header set to "deny".'
+						: ''),
 			);
 		}
 

--- a/packages/web-fragments/src/elements/reframed/reframed.ts
+++ b/packages/web-fragments/src/elements/reframed/reframed.ts
@@ -76,7 +76,8 @@ export function reframed(
 	let alreadyLoaded = false;
 
 	iframe.addEventListener('load', () => {
-		if (iframe.contentDocument?.head.childNodes.length !== 1 && iframe.contentDocument?.body.childNodes.length !== 0) {
+		// see web.ts, section "Handle IFrame request from reframed" for more details
+		if (iframe.contentDocument?.title !== 'Web Fragments: reframed') {
 			throw new WebFragmentError(
 				`Reframed IFrame init error!\n` +
 					`IFrame loaded unexpected content from ${iframe.src}!\n` +

--- a/packages/web-fragments/src/elements/reframed/utils/web-fragment-error.ts
+++ b/packages/web-fragments/src/elements/reframed/utils/web-fragment-error.ts
@@ -1,0 +1,1 @@
+export class WebFragmentError extends Error {}

--- a/packages/web-fragments/src/gateway/fragment-gateway.ts
+++ b/packages/web-fragments/src/gateway/fragment-gateway.ts
@@ -52,9 +52,9 @@ export class FragmentGateway {
 		fragmentConfig.piercing ??= true;
 
 		if (fragmentConfig.iframeHeaders) {
-			// normalize header name casing to Camel-Case
+			// normalize header name casing to HTTP-Header-Case (e.g. Content-Type, Sec-Fetch-Dest, etc.)
 			fragmentConfig.iframeHeaders = Object.fromEntries(
-				Object.entries(fragmentConfig.iframeHeaders!).map(([key, value]) => [
+				Object.entries(fragmentConfig.iframeHeaders).map(([key, value]) => [
 					[...key].reduce((acc, char) => {
 						if (acc === '') {
 							return char.toUpperCase();

--- a/packages/web-fragments/src/gateway/middleware/web-to-node-adapter.ts
+++ b/packages/web-fragments/src/gateway/middleware/web-to-node-adapter.ts
@@ -111,8 +111,8 @@ function interceptNodeResponse(
 	let originHead: ResponseInit;
 
 	let originHeadResolve: (response: ResponseInit) => void;
-	const originHeadPromise = new Promise<ResponseInit>((res) => {
-		originHeadResolve = res;
+	const originHeadPromise = new Promise<ResponseInit>((resolve) => {
+		originHeadResolve = resolve;
 	});
 
 	/**

--- a/packages/web-fragments/src/gateway/middleware/web.ts
+++ b/packages/web-fragments/src/gateway/middleware/web.ts
@@ -52,12 +52,14 @@ export function getWebMiddleware(
 		 */
 		if (requestSecFetchDest === 'iframe') {
 			return new Response('<!doctype html><title>', {
+				// !!! Important: the header name must be Camel-Cased for overriding via the iframesHeaders to work !!!
 				headers: {
 					'Content-Type': 'text/html;charset=UTF-8',
-					vary: 'sec-fetch-dest',
-					'x-web-fragment-id': matchedFragment.fragmentId,
+					Vary: 'sec-fetch-dest',
+					'X-Web-Fragment-Id': matchedFragment.fragmentId,
 					// cache the response for 1 hour and then revalidate in the background just in case we need to make some changes to the served content in the future
 					'Cache-Control': 'max-age=3600, public, stale-while-revalidate=31536000',
+					...matchedFragment.iframeHeaders,
 				},
 			});
 		}

--- a/packages/web-fragments/src/gateway/middleware/web.ts
+++ b/packages/web-fragments/src/gateway/middleware/web.ts
@@ -434,7 +434,7 @@ export function prefixHtmlHeadBody(fragmentResponse: Response): Response {
 				element.tagName = 'wf-body';
 			},
 		})
-		.transform(new Response(fragmentResponse.body, fragmentResponse));
+		.transform(fragmentResponse);
 }
 
 /**

--- a/packages/web-fragments/src/gateway/middleware/web.ts
+++ b/packages/web-fragments/src/gateway/middleware/web.ts
@@ -51,7 +51,8 @@ export function getWebMiddleware(
 		 * However, we don't want the iframe's document to actually contain the fragment's content; we're only using it as an isolated execution context. Returning a stub document here is our workaround to that problem.
 		 */
 		if (requestSecFetchDest === 'iframe') {
-			return new Response('<!doctype html><title>', {
+			// The title below is used be reframed to detect gateway misconfiguration. See reframed.ts
+			return new Response('<!doctype html><title>Web Fragments: reframed', {
 				// !!! Important: the header name must be Camel-Cased for overriding via the iframesHeaders to work !!!
 				headers: {
 					'Content-Type': 'text/html;charset=UTF-8',

--- a/packages/web-fragments/test/gateway/gateway.spec.ts
+++ b/packages/web-fragments/test/gateway/gateway.spec.ts
@@ -450,7 +450,7 @@ for (const environment of environments) {
 				);
 
 				expect(response.status).toBe(200);
-				expect(await response.text()).toBe(`<!doctype html><title>`);
+				expect(await response.text()).toBe(`<!doctype html><title>Web Fragments: reframed`);
 				expect(Object.fromEntries(response.headers.entries())).toMatchObject({
 					'content-type': 'text/html;charset=UTF-8',
 					vary: 'sec-fetch-dest',
@@ -469,7 +469,7 @@ for (const environment of environments) {
 				);
 
 				expect(response2.status).toBe(200);
-				expect(await response2.text()).toBe(`<!doctype html><title>`);
+				expect(await response2.text()).toBe(`<!doctype html><title>Web Fragments: reframed`);
 				expect(Object.fromEntries(response2.headers.entries())).toMatchObject({
 					'content-type': 'text/html;charset=UTF-8',
 					vary: 'sec-fetch-dest',
@@ -486,7 +486,7 @@ for (const environment of environments) {
 				);
 
 				expect(response.status).toBe(200);
-				expect(await response.text()).toBe(`<!doctype html><title>`);
+				expect(await response.text()).toBe(`<!doctype html><title>Web Fragments: reframed`);
 				expect(Object.fromEntries(response.headers.entries())).toMatchObject({
 					// over-written by the fragment config
 					'content-type': 'application/xhtml+xml',

--- a/packages/web-fragments/test/playground/fragment-csp/fragment.html
+++ b/packages/web-fragments/test/playground/fragment-csp/fragment.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<title>CSP test fragment</title>
+	</head>
+	<body>
+		<h2>CSP test fragment</h2>
+		<button id="fragment-eval-button">Click me to try to eval() inside of a fragment</button>
+		<script>
+			document.getElementById('fragment-eval-button').addEventListener('click', () => {
+				eval('alert("clicked")');
+			});
+		</script>
+	</body>
+</html>

--- a/packages/web-fragments/test/playground/fragment-csp/index.html
+++ b/packages/web-fragments/test/playground/fragment-csp/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<title>WF Playground: fragment-csp</title>
+		<style>
+			web-fragment {
+				border: 1px red dashed;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>WF Playground: fragment-csp</h1>
+
+		<button id="host-eval-button">Click me to try to eval() outside of a fragment</button>
+		<script>
+			document.getElementById('host-eval-button').addEventListener('click', () => {
+				eval('alert("clicked")');
+			});
+		</script>
+
+		<script type="module">
+			import { initializeWebFragments } from 'web-fragments';
+			initializeWebFragments();
+		</script>
+
+		<web-fragment fragment-id="fragment-csp"></web-fragment>
+	</body>
+</html>

--- a/packages/web-fragments/test/playground/fragment-csp/spec.ts
+++ b/packages/web-fragments/test/playground/fragment-csp/spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+const { beforeEach, describe, step } = test;
+import { failOnBrowserErrors } from '../playwright.utils';
+
+beforeEach(failOnBrowserErrors);
+
+describe('fragment Content Security Policy (CSP)', () => {
+	let lastError: Error;
+
+	beforeEach(async ({ page }) => {
+		await page.goto('/fragment-csp/');
+
+		page.on('pageerror', async (error) => {
+			lastError = error;
+		});
+
+		await step('ensure the test harness app loaded', async () => {
+			await expect(page).toHaveTitle('WF Playground: fragment-csp');
+			await expect(page.locator('h1')).toHaveText('WF Playground: fragment-csp');
+		});
+	});
+
+	test(`triggering eval() from the host app should work since the host app's CSP allows it`, async ({ page }) => {
+		let alertFired = false;
+
+		page.on('dialog', (dialog) => {
+			alertFired = true;
+			dialog.accept();
+		});
+
+		const button = page.locator('button#host-eval-button');
+		await button.click();
+		expect(alertFired).toBe(true);
+	});
+
+	test(`triggering eval() from the fragment app should FAIL since the fragment app's CSP disallows it`, async ({
+		page,
+	}) => {
+		let alertFired = false;
+
+		page.on('dialog', (dialog) => {
+			alertFired = true;
+			dialog.accept();
+		});
+
+		const button = page.locator('button#fragment-eval-button');
+		await button.click();
+		expect(alertFired).toBe(false);
+	});
+});

--- a/packages/web-fragments/test/playground/fragment-infinite-recursion-breaker/index.html
+++ b/packages/web-fragments/test/playground/fragment-infinite-recursion-breaker/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<title>WF Playground: fragment-infinite-recursion-breaker</title>
+		<style>
+			web-fragment {
+				border: 1px red dashed;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>WF Playground: fragment-infinite-recursion-breaker</h1>
+
+		<script type="module">
+			import { initializeWebFragments } from 'web-fragments';
+			initializeWebFragments();
+		</script>
+
+		<web-fragment fragment-id="fragment-infinite-recursion-breaker"></web-fragment>
+	</body>
+</html>

--- a/packages/web-fragments/test/playground/fragment-infinite-recursion-breaker/spec.ts
+++ b/packages/web-fragments/test/playground/fragment-infinite-recursion-breaker/spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+const { beforeEach, step } = test;
+import { failOnBrowserErrors } from '../playwright.utils';
+
+beforeEach(failOnBrowserErrors);
+
+test('fragment infinite recursion breaker', async ({ page }) => {
+	let lastError: Error;
+	page.on('pageerror', async (error) => {
+		lastError = error;
+	});
+
+	await page.goto('/fragment-infinite-recursion-breaker/');
+
+	await step('ensure the test harness app loaded', async () => {
+		await expect(page).toHaveTitle('WF Playground: fragment-infinite-recursion-breaker');
+		await expect(page.locator('h1')).toHaveText('WF Playground: fragment-infinite-recursion-breaker');
+	});
+
+	await step('fragment embedded in the initial html should init', async () => {
+		const fragment = page.locator('web-fragment[fragment-id=fragment-infinite-recursion-breaker]');
+		expect(fragment).toBeAttached();
+		expect(await fragment.innerHTML()).toBe('');
+		expect(lastError?.message).toBe(
+			'Reframed IFrame init error!\n' +
+				`IFrame loaded unexpected content from http://localhost:${new URL(page.url()).port}/fragment-infinite-recursion-breaker/!\n` +
+				'Ensure that Web Fragment gateway contains a fragment registration with a path matching: /fragment-infinite-recursion-breaker/',
+		);
+	});
+});

--- a/packages/web-fragments/test/playground/fragment-infinite-recursion-breaker/spec.ts
+++ b/packages/web-fragments/test/playground/fragment-infinite-recursion-breaker/spec.ts
@@ -24,7 +24,7 @@ test('fragment infinite recursion breaker', async ({ page }) => {
 		expect(lastError?.message).toBe(
 			'Reframed IFrame init error!\n' +
 				`IFrame loaded unexpected content from http://localhost:${new URL(page.url()).port}/fragment-infinite-recursion-breaker/!\n` +
-				'Ensure that Web Fragment gateway contains a fragment registration with a path matching: /fragment-infinite-recursion-breaker/',
+				'Ensure that the Web Fragment gateway contains a fragment registration with "routePatterns" matching path: /fragment-infinite-recursion-breaker/',
 		);
 	});
 });

--- a/packages/web-fragments/test/playground/fragment-infinite-recursion-breaker/spec.ts
+++ b/packages/web-fragments/test/playground/fragment-infinite-recursion-breaker/spec.ts
@@ -23,7 +23,8 @@ test('fragment infinite recursion breaker', async ({ page }) => {
 		expect(await fragment.innerHTML()).toBe('');
 		expect(lastError?.message).toBe(
 			'Reframed IFrame init error!\n' +
-				`IFrame loaded unexpected content from http://localhost:${new URL(page.url()).port}/fragment-infinite-recursion-breaker/!\n` +
+				`IFrame loaded unexpected content for http://localhost:${new URL(page.url()).port}/fragment-infinite-recursion-breaker/!\n` +
+				'Expected document title to be "Web Fragments: reframed" but was "WF Playground: fragment-infinite-recursion-breaker"\n' +
 				'Ensure that the Web Fragment gateway contains a fragment registration with "routePatterns" matching path: /fragment-infinite-recursion-breaker/',
 		);
 	});

--- a/packages/web-fragments/test/playground/fragment-x-frame-options-deny/fragment.html
+++ b/packages/web-fragments/test/playground/fragment-x-frame-options-deny/fragment.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<title>x-frame-options-deny test fragment</title>
+	</head>
+	<body>
+		<h2>This fragment will never become interactive due to the iframe being blocked by the browser!</h2>
+		<button>Click me to (not) see an alert</button>
+		<script>
+			document.querySelector('button').addEventListener('click', () => {
+				alert('clicked');
+			});
+		</script>
+	</body>
+</html>

--- a/packages/web-fragments/test/playground/fragment-x-frame-options-deny/index.html
+++ b/packages/web-fragments/test/playground/fragment-x-frame-options-deny/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<title>WF Playground: fragment-x-frame-options-deny</title>
+		<style>
+			web-fragment {
+				border: 1px red dashed;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>WF Playground: fragment-x-frame-options-deny</h1>
+
+		<script type="module">
+			import { initializeWebFragments } from 'web-fragments';
+			initializeWebFragments();
+		</script>
+
+		<web-fragment fragment-id="fragment-x-frame-options-deny"></web-fragment>
+	</body>
+</html>

--- a/packages/web-fragments/test/playground/fragment-x-frame-options-deny/spec.ts
+++ b/packages/web-fragments/test/playground/fragment-x-frame-options-deny/spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+const { beforeEach, step } = test;
+import { failOnBrowserErrors } from '../playwright.utils';
+
+beforeEach(failOnBrowserErrors);
+
+test('fragment with iframe delivered with the x-frame-options=deny response header should fail gracefully', async ({
+	page,
+}) => {
+	let lastError: Error;
+	page.on('pageerror', async (error) => {
+		lastError = error;
+	});
+
+	await page.goto('/fragment-x-frame-options-deny/');
+
+	await step('ensure the test harness app loaded', async () => {
+		await expect(page).toHaveTitle('WF Playground: fragment-x-frame-options-deny');
+		await expect(page.locator('h1')).toHaveText('WF Playground: fragment-x-frame-options-deny');
+	});
+
+	await step('fragment should forcefully fail when x-frame-options=deny is set', async () => {
+		const fragment = page.locator('web-fragment[fragment-id=fragment-x-frame-options-deny]');
+		expect(fragment).toBeAttached();
+		expect(await fragment.innerHTML()).toBe('');
+		expect(lastError?.message).toBe(
+			'Reframed IFrame init error!\n' +
+				`IFrame loaded unexpected content from http://localhost:${new URL(page.url()).port}/fragment-x-frame-options-deny/!\n` +
+				'Ensure that the Web Fragment gateway contains a fragment registration with "routePatterns" matching path: /fragment-x-frame-options-deny/\n' +
+				'Additionally, ensure that the iframe response is not delivered with the "X-Frame-Options" response header set to "deny".',
+		);
+	});
+});

--- a/packages/web-fragments/test/playground/fragment-x-frame-options-deny/spec.ts
+++ b/packages/web-fragments/test/playground/fragment-x-frame-options-deny/spec.ts
@@ -25,7 +25,8 @@ test('fragment with iframe delivered with the x-frame-options=deny response head
 		expect(await fragment.innerHTML()).toBe('');
 		expect(lastError?.message).toBe(
 			'Reframed IFrame init error!\n' +
-				`IFrame loaded unexpected content from http://localhost:${new URL(page.url()).port}/fragment-x-frame-options-deny/!\n` +
+				`IFrame loaded unexpected content for http://localhost:${new URL(page.url()).port}/fragment-x-frame-options-deny/!\n` +
+				'Expected document title to be "Web Fragments: reframed" but was "undefined"\n' +
 				'Ensure that the Web Fragment gateway contains a fragment registration with "routePatterns" matching path: /fragment-x-frame-options-deny/\n' +
 				'Additionally, ensure that the iframe response is not delivered with the "X-Frame-Options" response header set to "deny".',
 		);

--- a/packages/web-fragments/test/playground/index.html
+++ b/packages/web-fragments/test/playground/index.html
@@ -19,6 +19,7 @@
 			<li>
 				<a href="/fragment-infinite-recursion-breaker/">/fragment-infinite-recursion-breaker/</a>
 			</li>
+			<li><a href="/fragment-x-frame-options-deny/">/fragment-x-frame-options-deny/</a></li>
 			<li><a href="/dom-isolation/">/dom-isolation/</a> (<a href="/dom-isolation/fragment">fragment</a>)</li>
 
 			<li><a href="/dom-querying/">/dom-querying/</a> (<a href="/dom-querying/fragment">fragment</a>)</li>

--- a/packages/web-fragments/test/playground/index.html
+++ b/packages/web-fragments/test/playground/index.html
@@ -16,6 +16,9 @@
 					>fragment</a
 				>)
 			</li>
+			<li>
+				<a href="/fragment-infinite-recursion-breaker/">/fragment-infinite-recursion-breaker/</a>
+			</li>
 			<li><a href="/dom-isolation/">/dom-isolation/</a> (<a href="/dom-isolation/fragment">fragment</a>)</li>
 
 			<li><a href="/dom-querying/">/dom-querying/</a> (<a href="/dom-querying/fragment">fragment</a>)</li>

--- a/packages/web-fragments/test/playground/index.html
+++ b/packages/web-fragments/test/playground/index.html
@@ -16,6 +16,7 @@
 					>fragment</a
 				>)
 			</li>
+			<li><a href="/fragment-csp/">/fragment-csp/</a> (<a href="/fragment-csp/fragment">fragment</a>)</li>
 			<li>
 				<a href="/fragment-infinite-recursion-breaker/">/fragment-infinite-recursion-breaker/</a>
 			</li>

--- a/packages/web-fragments/test/playground/location-and-history/spec.ts
+++ b/packages/web-fragments/test/playground/location-and-history/spec.ts
@@ -369,10 +369,6 @@ test('hard nav and reload behavior in a bound fragment', async ({ page }) => {
 	// popstateCount is now 0 because we reloaded
 	expect(await main.popstateCount()).toBe('0');
 
-	page.context().route('/baz', (route) => {
-		return route.fulfill({ body: 'baz' });
-	});
-
 	bound.hardNavToBazButton.click();
 	await page.waitForEvent('load', {
 		predicate: (page) => {

--- a/packages/web-fragments/test/playground/playwright.utils.ts
+++ b/packages/web-fragments/test/playground/playwright.utils.ts
@@ -13,6 +13,7 @@ export function failOnBrowserErrors({ page }: { page: Page }) {
 	page.on('pageerror', async (error) => {
 		// ignore errors for tests that test error handling
 		if ((await page.title()) === 'WF Playground: fragment-infinite-recursion-breaker') return;
+		if ((await page.title()) === 'WF Playground: fragment-x-frame-options-deny') return;
 
 		// prefix error with [browser] so that it's easier to distinguish from Playwright/Node.js errors
 		error.message = `[browser]: ${error.message}`;

--- a/packages/web-fragments/test/playground/playwright.utils.ts
+++ b/packages/web-fragments/test/playground/playwright.utils.ts
@@ -11,9 +11,13 @@ export default function globalSetup({ webServer }: { webServer: { command: strin
 export function failOnBrowserErrors({ page }: { page: Page }) {
 	// Abort a test if an exception in the browser is detected
 	page.on('pageerror', async (error) => {
-		// ignore errors for tests that test error handling
-		if ((await page.title()) === 'WF Playground: fragment-infinite-recursion-breaker') return;
-		if ((await page.title()) === 'WF Playground: fragment-x-frame-options-deny') return;
+		// ignore/allow errors for tests that test error handling
+		switch (await page.title()) {
+			case 'WF Playground: fragment-infinite-recursion-breaker':
+			case 'WF Playground: fragment-x-frame-options-deny':
+			case 'WF Playground: fragment-csp':
+				return;
+		}
 
 		// prefix error with [browser] so that it's easier to distinguish from Playwright/Node.js errors
 		error.message = `[browser]: ${error.message}`;

--- a/packages/web-fragments/test/playground/playwright.utils.ts
+++ b/packages/web-fragments/test/playground/playwright.utils.ts
@@ -11,6 +11,9 @@ export default function globalSetup({ webServer }: { webServer: { command: strin
 export function failOnBrowserErrors({ page }: { page: Page }) {
 	// Abort a test if an exception in the browser is detected
 	page.on('pageerror', async (error) => {
+		// ignore errors for tests that test error handling
+		if ((await page.title()) === 'WF Playground: fragment-infinite-recursion-breaker') return;
+
 		// prefix error with [browser] so that it's easier to distinguish from Playwright/Node.js errors
 		error.message = `[browser]: ${error.message}`;
 		// rewrite stack trace to align it with the filesystem path to make stack frames easier to navigate

--- a/packages/web-fragments/test/playground/public/baz/index.html
+++ b/packages/web-fragments/test/playground/public/baz/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<title>baz</title>
+	</head>
+	<body>
+		<h2>baz</h2>
+		<p>this file is used in location-and-history tests</p>
+	</body>
+</html>

--- a/packages/web-fragments/test/playground/vite.config.ts
+++ b/packages/web-fragments/test/playground/vite.config.ts
@@ -77,7 +77,11 @@ async function configureGatewayMiddleware(server: ViteDevServer | PreviewServer)
 async function getFragmentGatewayMiddleware(getServerUrl: () => string) {
 	const fragmentGateway = new FragmentGateway();
 	(await glob('**/', { ignore: ['dist/**', 'public/**', 'node_modules/**'] })).forEach((appDir) => {
+		// ignore current dir
 		if (appDir === '.') return;
+
+		// don't register fragment for a special test that validates we don't infinitely recurse when a fragment is not registered
+		if (appDir === 'fragment-infinite-recursion-breaker') return;
 
 		const fragmentId = path.basename(appDir);
 

--- a/packages/web-fragments/test/playground/vite.config.ts
+++ b/packages/web-fragments/test/playground/vite.config.ts
@@ -94,6 +94,7 @@ async function getFragmentGatewayMiddleware(getServerUrl: () => string) {
 				return getServerUrl();
 			},
 			prePiercingClassNames: [],
+			iframeHeaders: fragmentId === 'fragment-x-frame-options-deny' ? { 'X-Frame-Options': 'deny' } : undefined,
 		});
 	});
 

--- a/packages/web-fragments/test/playground/vite.config.ts
+++ b/packages/web-fragments/test/playground/vite.config.ts
@@ -41,12 +41,30 @@ export default defineConfig({
 
 	plugins: [
 		{
+			name: 'playground-redirects-middleware',
+			configureServer: configurePlaygroundRedirectsMiddleware,
+			configurePreviewServer: configurePlaygroundRedirectsMiddleware,
+		},
+		{
 			name: 'web-fragments-middleware',
 			configureServer: configureGatewayMiddleware,
 			configurePreviewServer: configureGatewayMiddleware,
 		},
 	],
 });
+
+async function configurePlaygroundRedirectsMiddleware(server: ViteDevServer | PreviewServer) {
+	server.middlewares.use(function playgroundRedirectMiddleware(
+		req: http.IncomingMessage,
+		res: http.ServerResponse,
+		next: () => void,
+	) {
+		if (req.url === '/baz/' || req.url === '/baz') {
+			req.url = '/baz/index.html';
+		}
+		next();
+	});
+}
 
 async function configureGatewayMiddleware(server: ViteDevServer | PreviewServer) {
 	let serverUrl: string;


### PR DESCRIPTION
If the fragment gateway was not properly configured (e.g. the routePaths don't contain the main navigable url that starts a fragment), reframed creates an iframe which when loaded by the browser loads the original host html rather than the minimal reframed init html, which then causes a new nested fragment to be created which then repeats the process, resulting in an infinite recursion.

This turns out to be a rather common user error, so to make it easier to diagnose and fix, we now detect it and throw an error.
