### PR TITLE
fix: fix window.matchMedia to operate on the visible window/document

### DIFF
--- a/.changeset/thin-otters-cover.md
+++ b/.changeset/thin-otters-cover.md
@@ -1,0 +1,7 @@
+---
+'web-fragments': patch
+---
+
+fix: fix window.matchMedia to operate on the visible window/document
+
+By default they operate on the iframe, which returns non-sense values.

--- a/packages/web-fragments/src/elements/reframed/iframe-patches.ts
+++ b/packages/web-fragments/src/elements/reframed/iframe-patches.ts
@@ -73,6 +73,7 @@ export function initializeIFrameContext(
 	iframeWindow.IntersectionObserver = mainWindow.IntersectionObserver;
 	iframeWindow.MutationObserver = mainWindow.MutationObserver;
 	iframeWindow.ResizeObserver = mainWindow.ResizeObserver;
+	iframeWindow.matchMedia = mainWindow.matchMedia.bind(mainWindow); // needs to be bound to mainWindow otherwise operates on the iframe window
 
 	const windowSizeProperties: (keyof Pick<
 		Window,

--- a/packages/web-fragments/test/playground/reframing/spec.ts
+++ b/packages/web-fragments/test/playground/reframing/spec.ts
@@ -51,3 +51,9 @@ test('Node, Document, Element be from the to the main context', async ({ page })
 	expect(await fragmentContext.evaluate(`document.querySelector('h2') instanceof Element`)).toBe(true);
 	expect(await fragmentContext.evaluate(`document.querySelector('h2').firstChild instanceof Text`)).toBe(true);
 });
+
+//window.matchMedia('(max-width: 755px)')
+test('matchMedia should delegate to the main context', async ({ page }) => {
+	// the iframe window/document have 0px width so '(max-width: 755px)' returns false unless patched
+	expect(await fragmentContext.evaluate(`window.matchMedia('(max-width: 755px)').matches`)).toBe(false);
+});


### PR DESCRIPTION
By default they operate on the iframe, which returns non-sense values.

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

- ...

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[ ] No
```
