### PR TITLE
fix: correctly update document.title

### DIFF
--- a/.changeset/gentle-houses-rule.md
+++ b/.changeset/gentle-houses-rule.md
@@ -1,0 +1,9 @@
+---
+'web-fragments': patch
+---
+
+fix: correctly update document.title
+
+Setting document.title should actually update the `<title>` element within the `<head>` of the fragment.
+
+And bound fragments should also update parent's document.title — for bound fragments the title is a shared state, just like window.location and history.

--- a/packages/web-fragments/src/elements/reframed/iframe-patches.ts
+++ b/packages/web-fragments/src/elements/reframed/iframe-patches.ts
@@ -213,8 +213,6 @@ export function initializeIFrameContext(
 	/**
 	 * START> DOCUMENT PATCHES
 	 */
-	let updatedIframeTitle: string | undefined = undefined;
-
 	setInternalReference(iframeDocument, 'body');
 
 	const getUnpatchedIframeDocumentCurrentScript = Object.getOwnPropertyDescriptor(
@@ -226,14 +224,18 @@ export function initializeIFrameContext(
 		title: {
 			get: function () {
 				return (
-					updatedIframeTitle ??
 					// https://html.spec.whatwg.org/multipage/dom.html#document.title
-					wfDocumentElement.querySelector('title')?.textContent?.trim() ??
-					'[reframed document]'
+					wfDocumentElement.querySelector('title')?.textContent?.trim() ?? '[reframed document]'
 				);
 			},
 			set: function (newTitle: string) {
-				updatedIframeTitle = newTitle;
+				const titleElement = wfDocumentElement.querySelector('title');
+				if (titleElement) {
+					titleElement.textContent = newTitle;
+				}
+				if (boundNavigation) {
+					mainDocument.title = newTitle;
+				}
 			},
 		},
 

--- a/packages/web-fragments/test/playground/reframing/spec.ts
+++ b/packages/web-fragments/test/playground/reframing/spec.ts
@@ -52,8 +52,17 @@ test('Node, Document, Element be from the to the main context', async ({ page })
 	expect(await fragmentContext.evaluate(`document.querySelector('h2').firstChild instanceof Text`)).toBe(true);
 });
 
-//window.matchMedia('(max-width: 755px)')
 test('matchMedia should delegate to the main context', async ({ page }) => {
 	// the iframe window/document have 0px width so '(max-width: 755px)' returns false unless patched
 	expect(await fragmentContext.evaluate(`window.matchMedia('(max-width: 755px)').matches`)).toBe(false);
+});
+
+test('document.title should read the value from <title> element, and write to it as well', async ({ page }) => {
+	expect(await fragmentContext.evaluate(`document.title`)).toBe('hello fragment');
+	// TODO: should we update the parent title when a bound fragment is initialized?
+	//expect(await page.evaluate(`document.title`)).toBe('hello fragment');
+	expect(await fragmentContext.evaluate(`document.title = 'hello fragment 2'`)).toBe('hello fragment 2');
+	expect(await fragmentContext.evaluate(`document.title`)).toBe('hello fragment 2');
+	// and we should also update the parent title
+	expect(await page.evaluate(`document.title`)).toBe('hello fragment 2');
 });


### PR DESCRIPTION
Setting document.title should actually update the `<title>` element within the `<head>` of the fragment.

And bound fragments should also update parent's document.title — for bound fragments the title is a shared state, just like window.location and history.
