### PR TITLE
fix(reframed): Patch navigator API so iframe navigator uses the main …

### DIFF
--- a/.changeset/tender-cheetahs-brake.md
+++ b/.changeset/tender-cheetahs-brake.md
@@ -1,0 +1,5 @@
+---
+'web-fragments': patch
+---
+
+Proxy navigator.clipboard API to main window

--- a/e2e/pierced-react/fragments/qwik/src/routes/qwik-page/index.tsx
+++ b/e2e/pierced-react/fragments/qwik/src/routes/qwik-page/index.tsx
@@ -15,12 +15,12 @@ export default component$(() => {
       margin: 1rem;
       width: fit-content;
       color: black;
- 
+
       p {
         margin-bottom: 0.5rem;
         text-align: center;
       }
- 
+
       .counter {
         display: flex;
         gap: 1rem;
@@ -54,6 +54,7 @@ export default component$(() => {
 						>
 							+
 						</button>
+						<button onClick$={() => navigator.clipboard.writeText(counter.value.toString())}>copy</button>
 					</div>
 					{new Array(1000).fill(undefined).map((_element, idx) => (
 						<div key={idx}>I am the {idx} element in this list of divs</div>

--- a/e2e/pierced-react/fragments/remix/app/routes/remix-page.tsx
+++ b/e2e/pierced-react/fragments/remix/app/routes/remix-page.tsx
@@ -69,6 +69,7 @@ export default function Index() {
 						>
 							+
 						</button>
+						<button onClick={() => navigator.clipboard.writeText(counter.toString())}>copy</button>
 					</div>
 					{new Array(1000).fill(undefined).map((_element, idx) => (
 						<div key={idx}>I am the {idx} element in this list of divs</div>

--- a/packages/web-fragments/src/elements/reframed/iframe-patches.ts
+++ b/packages/web-fragments/src/elements/reframed/iframe-patches.ts
@@ -74,6 +74,13 @@ export function initializeIFrameContext(
 	iframeWindow.MutationObserver = mainWindow.MutationObserver;
 	iframeWindow.ResizeObserver = mainWindow.ResizeObserver;
 	iframeWindow.matchMedia = mainWindow.matchMedia.bind(mainWindow); // needs to be bound to mainWindow otherwise operates on the iframe window
+	// the navigator API is defined as enumerable and configurable property with a getter and an undefined setter
+	Object.defineProperty(iframeWindow, 'navigator', {
+		set: undefined,
+		get: () => mainWindow.navigator,
+		configurable: true,
+		enumerable: true,
+	});
 
 	// dispatch events onto the shadowRoot if the event is not one of the special iframe events
 	const originalDispatchEvent = iframeWindow.dispatchEvent.bind(iframeWindow);

--- a/packages/web-fragments/test/playground/playwright.config.ts
+++ b/packages/web-fragments/test/playground/playwright.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
 	projects: [
 		{
 			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] },
+			use: { ...devices['Desktop Chrome'], permissions: ['clipboard-read', 'clipboard-write'] },
 		},
 		{
 			name: 'firefox',

--- a/packages/web-fragments/test/playground/reframing/fragment.html
+++ b/packages/web-fragments/test/playground/reframing/fragment.html
@@ -6,9 +6,19 @@
 	</head>
 	<body>
 		<h2>hello</h2>
+
+		<button id="clipboardWriteButton">Write to clipboard</button>
+		<button id="clipboardReadButton">Read and print clipboard</button>
 		<script>
 			const name = new URL(location.href).searchParams.get('name') ?? 'world';
 			document.querySelector('h2').textContent += ` ${name}!`;
+
+			document.querySelector('#clipboardWriteButton').addEventListener('click', () => {
+				navigator.clipboard.writeText(`${location.href} @ ${new Date().toString()}`);
+			});
+			document.querySelector('#clipboardReadButton').addEventListener('click', async () => {
+				alert('Clipboard content: ' + (await navigator.clipboard.readText()));
+			});
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
# The problem (initially):
When a reframed script tries to call `navigator.clipboard.writeText('hello, world!')`, the iframe does not have focus and an exception is thrown: `Uncaught (in promise) NotAllowedError: Failed to execute 'writeText' on 'Clipboard': Document is not focused.`

# The "easy" solution ~(not used in this PR!)~
Adding the follow line below [here](https://github.com/web-fragments/web-fragments/blob/main/packages/web-fragments/src/elements/reframed/iframe-patches.ts#L76-L76):
```js
Object.defineProperty(iframeWindow.navigator, 'clipboard', {
	value: mainWindow.navigator.clipboard,
	writable: false,
});
```

This would re-assign the `navigator.clipboard` in the iframe window to reference the `navigator.clipboard` from the parent window, and solves the problem above.

# Considerations:
The [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) does have events, should these be triggered in the main window by fragments? Should "Fragment A" also get an event when "Fragment B" performs some action with the clipboard?

More broadly, there are many API's on `window.navigator` that normally require a [permission policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Permissions_Policy) when used inside of an iframe. If we want these API's to work seamlessly, perhaps we should replace the whole `navigator` [object](https://developer.mozilla.org/en-US/docs/Web/API/Navigator) with the parent's?
```js
Object.defineProperty(iframeWindow, 'navigator', {
	value: mainWindow.navigator,
	writable: false,
});
```

This seems *mostly* fine, and maybe even desirable. For example, it might make sense for the [UserActivation](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userActivation) API to be shared across all fragments. But there are also some navigator API's I'm not so sure about like the [MediaSession](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/mediaSession) API which maybe should be isolated per-fragment.

I mostly wanted to open this PR to start talking about this!

## Does this introduce a breaking change?

It kinda does I think

```
[x] Yes
[ ] No
```
