### PR TITLE
fix(reframed): make browser API patching more resilient to defend against browser extensions

### DIFF
--- a/.changeset/cuddly-bulldogs-work.md
+++ b/.changeset/cuddly-bulldogs-work.md
@@ -1,0 +1,28 @@
+---
+'web-fragments': patch
+---
+
+fix(reframed): make browser API patching more resilient to defend against browser extensions
+
+Some browser extensions incorrectly patch browser APIs in ways that prevent Web Fragments from working correctly.
+
+The most recent offender is Dashlane password manager (https://www.dashlane.com/), which patches the `hasInstance` property of global constructors with non-configurable descriptors, which prevents further patching by WebFragments.
+
+To defend against such issues, WebFragments now catches patching errors, issues a warning including the error details, and continues patching the remaining APIs.
+
+It's likely that many applications will work just fine even with a few browser APIs unpatched, so this approach is preferable to fatal errors that crash the apps.
+
+Example warning:
+
+```
+WebFragments: failed to patch `PublicKeyCredential[Symbol.hasInstance]`
+A browser extension might be interfering with the browser APIs...
+Some application functionality may not work as expected!
+Error: TypeError: Cannot redefine property: Symbol(Symbol.hasInstance)
+    at Object.defineProperty (<anonymous>)
+    at cf-fragments.4eb1694958c0444acce6.js:533:48
+    at Array.forEach (<anonymous>)
+    at cf-fragments.4eb1694958c0444acce6.js:531:174
+    at HTMLIFrameElement.<anonymous> (cf-fragments.4eb1694958c0444acce6.js:895:34)
+Descriptor: {value: Proxy(Function), writable: false, enumerable: false, configurable: false}
+```

--- a/packages/web-fragments/src/elements/reframed/iframe-patches.ts
+++ b/packages/web-fragments/src/elements/reframed/iframe-patches.ts
@@ -61,9 +61,19 @@ export function initializeIFrameContext(
 	// extend global constructors to support instanceof checks using
 	// their equivalent constructor from the parent execution context
 	globalConstructors.forEach((constructor) => {
-		Object.defineProperty(constructor, Symbol.hasInstance, {
-			value: hasInstance,
-		});
+		try {
+			Object.defineProperty(constructor, Symbol.hasInstance, {
+				value: hasInstance,
+			});
+		} catch (e) {
+			console.warn(
+				`WebFragments: failed to patch \`${constructor.name}[Symbol.hasInstance]\`\nA browser extension might be interfering with the browser APIs...\nSome application functionality may not work as expected!`,
+				'\nError:',
+				e,
+				`\nDescriptor:`,
+				Object.getOwnPropertyDescriptor(constructor, Symbol.hasInstance),
+			);
+		}
 	});
 	// END> WINDOW: GLOBAL CONSTRUCTORS PATCHES
 


### PR DESCRIPTION
Some browser extensions incorrectly patch browser APIs in ways that prevent Web Fragments from working correctly.

The most recent offender is Dashlane password manager (https://www.dashlane.com/), which patches the `hasInstance` property of global constructors with non-configurable descriptors, which prevents further patching by WebFragments.

To defend against such issues, WebFragments now catches patching errors, issues a warning including the error details, and continues patching the remaining APIs.

It's likely that many applications will work just fine even with a few browser APIs unpatched, so this approach is preferable to fatal errors that crash the apps.

Example warning:

```
WebFragments: failed to patch `PublicKeyCredential[Symbol.hasInstance]`
A browser extension might be interfering with the browser APIs...
Some application functionality may not work as expected!
Error: TypeError: Cannot redefine property: Symbol(Symbol.hasInstance)
    at Object.defineProperty (<anonymous>)
    at cf-fragments.4eb1694958c0444acce6.js:533:48
    at Array.forEach (<anonymous>)
    at cf-fragments.4eb1694958c0444acce6.js:531:174
    at HTMLIFrameElement.<anonymous> (cf-fragments.4eb1694958c0444acce6.js:895:34)
Descriptor: {value: Proxy(Function), writable: false, enumerable: false, configurable: false}
```

I also filed a bug report with Dashlane: https://github.com/Dashlane/dashlane-web-extension/issues/4