### PR TITLE
fix(gateway): correctly insert shadow root between web-fragment and web-fragment-host during piercing into SSR-ed host

### DIFF
--- a/.changeset/chilled-turtles-dress.md
+++ b/.changeset/chilled-turtles-dress.md
@@ -1,0 +1,9 @@
+---
+'web-fragments': patch
+---
+
+fix(gateway): correctly insert shadow root between web-fragment and web-fragment-host during piercing into SSR-ed host
+
+Before this fix, piercing into SSR-ed host would not work because the shadow root was not inserted between the web-fragment and web-fragment-host elements.
+
+This was due to us having two code paths where this logic happens and only the WASM HTMLRewriter implementation was inserting the shadow root.

--- a/packages/web-fragments/src/gateway/middleware/web.ts
+++ b/packages/web-fragments/src/gateway/middleware/web.ts
@@ -320,10 +320,12 @@ export function getWebMiddleware(
 				.on('web-fragment', {
 					element(element) {
 						if (element.getAttribute('fragment-id') !== fragmentId) return;
+						element.append('<template shadowrootmode="open">', { html: true });
 
 						(element.append as any as (content: ReadableStream, options: { html: boolean }) => void)(fragmentStream, {
 							html: true,
 						});
+						element.append('</template>', { html: true });
 						fragmentPierced = true;
 					},
 				})


### PR DESCRIPTION
Before this fix, piercing into SSR-ed host would not work because the shadow root was not inserted between the web-fragment and web-fragment-host elements.

This was due to us having two code paths where this logic happens and only the WASM HTMLRewriter implementation was inserting the shadow root.
