### PR TITLE
chore: migrate to the upstream writable-dom

### DIFF
--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -60,7 +60,7 @@
 		"@types/node": "^20.12.7",
 		"path-to-regexp": "^6.2.2",
 		"ts-node-dev": "^2.0.0",
-		"writable-dom": "github:web-fragments/writable-dom#build-improvements",
+		"writable-dom": "^1.0.6",
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,8 +417,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.5(@types/debug@4.1.12)(@types/node@20.14.10)(lightningcss@1.27.0)(terser@5.34.1)
       writable-dom:
-        specifier: github:web-fragments/writable-dom#build-improvements
-        version: https://codeload.github.com/web-fragments/writable-dom/tar.gz/5d461949c30843ffc79eb63a98c3c751aae985b6
+        specifier: ^1.0.6
+        version: 1.0.6
 
   packages/web-fragments/test/gateway:
     devDependencies:
@@ -7786,9 +7786,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  writable-dom@https://codeload.github.com/web-fragments/writable-dom/tar.gz/5d461949c30843ffc79eb63a98c3c751aae985b6:
-    resolution: {tarball: https://codeload.github.com/web-fragments/writable-dom/tar.gz/5d461949c30843ffc79eb63a98c3c751aae985b6}
-    version: 1.0.0
+  writable-dom@1.0.6:
+    resolution: {integrity: sha512-sky15kmZw2kQXP9n4GOCeO8orSI61A9z9l6NGrbHRiWiUJnUVjHcSTrVKa9Av3lF97eYy87efFCmTnIg1dgRUg==}
 
   ws@7.5.10:
     resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
@@ -17189,7 +17188,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  writable-dom@https://codeload.github.com/web-fragments/writable-dom/tar.gz/5d461949c30843ffc79eb63a98c3c751aae985b6: {}
+  writable-dom@1.0.6: {}
 
   ws@7.5.10: {}
 


### PR DESCRIPTION
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Looking at the commits in your writable-dom fork: https://github.com/marko-js/writable-dom/compare/main...web-fragments:writable-dom:build-improvements
It seems those related to typescript / build issues are no longer relevant as upstream changed the build step.
The one related to github URI is not relevant when the npm release is used, but I upstreamed that change.

For now this is a draft as there are some problems and it doesn't pass the tests, probably some change in the writable-dom broke something here.
In particular seem to be related to this commit: https://github.com/marko-js/writable-dom/commit/08e9e6d851d51ef115e7b0f40b913f846f7fa1db

Closes: https://github.com/web-fragments/web-fragments/issues/103

Does this need a changeset?

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```
