### PR TITLE
docs: add YouTube video and fix 4-column grid layout

### DIFF
--- a/docs/src/components/ui/ItemGrid2.astro
+++ b/docs/src/components/ui/ItemGrid2.astro
@@ -50,7 +50,7 @@ const {
 const gridClasses = twMerge(
   `grid grid-cols-1 gap-[20px] ${
     columns === 4
-      ? "sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+      ? "sm:grid-cols-2 lg:grid-cols-4"
       : columns === 3
         ? "sm:grid-cols-2 lg:grid-cols-3"
         : columns === 2

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -49,7 +49,9 @@ const metadata = {
 			</span>
 		</Fragment>
 	</Hero>
-	<ItemGrid2 columns={3}>
+	<ItemGrid2 columns={4}>
+		<YouTube id="jtz7bBVKcOg" title="Web Fragments: The Future of Micro-frontends">
+		</YouTube>
 		<YouTube id="JY2Yjy2020I" title="Web Fragments at Scale">
 		</YouTube>
 		<YouTube id="sneufVyPfiY" params="start=5014&end=13637" title="Web-Fragments: Micro-frontends done right?">


### PR DESCRIPTION
## Summary
- Add "Web Fragments: The Future of Micro-frontends" (`jtz7bBVKcOg`) as the first video in the homepage video grid
- Switch from 3-column to 4-column layout
- Fix responsive breakpoints: remove `md:grid-cols-3` so videos display as a 2x2 grid on medium screens (640px–1024px) instead of 3+1

cc @anfibiacreativa

🤖 Generated with [Claude Code](https://claude.com/claude-code)