### PR TITLE
Prioritize requestFragmentId instead of urlPath when resolving the fragment config

### DIFF
--- a/packages/web-fragments/src/gateway/fragment-gateway.ts
+++ b/packages/web-fragments/src/gateway/fragment-gateway.ts
@@ -112,24 +112,19 @@ export class FragmentGateway {
 	}
 
 	matchRequestToFragment(urlPath: string, requestFragmentId?: string) {
+		if (requestFragmentId) {
+			const fragmentConfig = this.fragmentConfigs.get(requestFragmentId);
+
+			if (fragmentConfig) {
+				return fragmentConfig
+			}
+		}
+
 		// TODO: path matching needs to take pattern specificity into account
 		// such that more specific patterns are matched before less specific ones
 		//   e.g. given route patterns `['/:accountId', '/:accountId/workers']` and a request path of `/abc123/workers/foo`,
 		//   the matched pattern should be `/:accountId/workers` since it is the more specific pattern.
 		const matches = [...this.routeMap.keys()].filter((matcher) => matcher(urlPath));
-
-		for (const match of matches) {
-			const fragmentConfig = this.routeMap.get(match) ?? null;
-
-			if (!requestFragmentId) {
-				// if no fragmentId was not specified in the request, return the first matching fragment config
-				return fragmentConfig;
-			}
-
-			if (requestFragmentId === fragmentConfig?.fragmentId) {
-				return fragmentConfig;
-			}
-		}
 
 		// for backwards compatibility if we have a path match, but fragment id doesn't match any of the routes, return the first match
 		// TODO: remove this to increase security and resiliency once we have better request type identification


### PR DESCRIPTION
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

- From testing I noticed that route patterns defined for a fragment can be seen as split into two categories
  1. Request to the main index.html file of the fragment
  2. Subsequent requests to get any additional asset of the fragment
which can also be seen in different examples when registering fragments into the gateway where there is a unique route pattern (often prefixed by a namespace such as /__wf/<fragment-id>) which matches a baseHref defined in the fragment index.html and is used for requests of category 2., and a route pattern that matches the path where the fragment is expected to load in the host app (assuming the fragment is loaded as route-bound) with purpose of retrieving the index.html of the fragment (category 1.).
The concern  with this approach is that the fragment gateway has to be aware of routes defined in the host app making it more difficult to render a fragment with a unique id anywhere in the app. 
With the following [change](https://github.com/web-fragments/web-fragments/commit/f5b7702c6c96c16713d61502fa264a11bfde978d), when matching fragment config know also checks that, if provided (which is done so in the request of category 1.), the fragmentId header also matches one of the fragment configs of matched route patter, but in this case we would not need to check that the request path matches a routePattern of a fragment since we can already uniquely identify the fragment of the given id (assuming i exists, otherwise we default to know match), which is exactly what we propose doing with the change. The final result of this would allow removing dependency of the fragment gateway to routes defined in the host webapp and enable loading fragments anywhere given a corresponding fragmentId
 

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```
