### PR TITLE
fix(gateway): handle fragment fetch failures consistently

### DIFF
--- a/packages/web-fragments/src/gateway/middleware/web-to-node-adapter.ts
+++ b/packages/web-fragments/src/gateway/middleware/web-to-node-adapter.ts
@@ -40,6 +40,10 @@ export function webToNodeMiddleware(webMiddleware: (req: Request, next: () => Pr
 	};
 }
 
+interface RequestInitWithDuplex extends RequestInit {
+	duplex?: 'half';
+}
+
 function nodeRequestToWebRequest(nodeReq: http.IncomingMessage): Request {
 	const headers = new Headers();
 
@@ -56,11 +60,14 @@ function nodeRequestToWebRequest(nodeReq: http.IncomingMessage): Request {
 		body = stream.Readable.toWeb(nodeReq) as ReadableStream<Uint8Array>;
 	}
 
-	return new Request(nodeRequestToUrl(nodeReq), {
+	const requestInit: RequestInitWithDuplex = {
 		method: nodeReq.method,
 		headers,
 		body,
-	});
+		duplex: body ? 'half' : undefined,
+	};
+
+	return new Request(nodeRequestToUrl(nodeReq), requestInit);
 }
 
 export function nodeRequestToUrl(nodeReq: http.IncomingMessage): URL {

--- a/packages/web-fragments/src/gateway/middleware/web.ts
+++ b/packages/web-fragments/src/gateway/middleware/web.ts
@@ -120,7 +120,7 @@ export function getWebMiddleware(
 				.catch(renderErrorResponse);
 		}
 
-		const fragmentResponse = await fragmentResponsePromise!;
+		const fragmentResponse = await fragmentResponsePromise!.catch(handleFetchErrors);
 
 		/**
 		 * Handle SSR request from a soft navigation

--- a/packages/web-fragments/test/gateway/gateway.spec.ts
+++ b/packages/web-fragments/test/gateway/gateway.spec.ts
@@ -486,6 +486,27 @@ for (const environment of environments) {
 					expect(response.headers.get('location')).toBe('http://sso.test/login');
 					expect(await response.text()).toBe('');
 				});
+
+				it('should handle non-document fragment fetch errors through onSsrFetchError', async () => {
+					fetchMock.doMockIf('http://bar.test:4321/_fragment/bar/image.jpg', () => {
+						throw new Error('fragment server unavailable');
+					});
+
+					customFragmentBarOnSsrFetchError = async () => ({
+						response: new Response('custom unavailable', {
+							status: 503,
+							headers: { 'content-type': 'text/plain' },
+						}),
+					});
+
+					const response = await testRequest(
+						new Request('http://localhost/_fragment/bar/image.jpg', { headers: { 'sec-fetch-dest': 'image' } }),
+					);
+
+					expect(response.status).toBe(503);
+					expect(await response.text()).toBe('custom unavailable');
+					expect(response.headers.get('x-web-fragment-id')).toBe('fragmentBar');
+				});
 			});
 
 			describe(`web fragment styles`, () => {
@@ -573,6 +594,34 @@ for (const environment of environments) {
 		});
 
 		describe(`fragment soft navigation html requests`, () => {
+			it(`should preserve streamed bodies for non-GET fragment requests`, async () => {
+				fetchMock.doMockIf(
+					(request) => {
+						if (request.url.toString() === 'http://foo.test:1234/foo/some/path') {
+							expect(request.method).toBe('PATCH');
+							return true;
+						}
+						return false;
+					},
+					async (request) => {
+						expect(await request.text()).toBe('{"hello":"world"}');
+						return new Response('patched', { headers: { 'content-type': 'text/plain' } });
+					},
+				);
+
+				const response = await testRequest(
+					new Request('http://localhost/foo/some/path', {
+						method: 'PATCH',
+						headers: { 'content-type': 'application/json', 'sec-fetch-dest': 'empty' },
+						body: '{"hello":"world"}',
+						duplex: 'half',
+					}),
+				);
+
+				expect(response.status).toBe(200);
+				expect(await response.text()).toBe('patched');
+			});
+
 			it(`should serve a fragment soft navigation request`, async () => {
 				mockFragmentFooResponse(
 					'/foo/some/path',
@@ -1043,17 +1092,20 @@ for (const environment of environments) {
 					testRequest = async function nodeTestRequest(request: Request): Promise<Response> {
 						const newUrl = new URL(new URL(request.url).pathname, `http://localhost:${server.address()!.port}`);
 
-						const newRequest = new Request(newUrl, {
+						const requestInit: RequestInit & { duplex?: 'half' } = {
 							method: request.method,
 							headers: request.headers,
 							body: request.body,
+							duplex: request.body ? 'half' : undefined,
 							mode: request.mode,
 							credentials: request.credentials,
 							cache: request.cache,
 							redirect: request.redirect,
 							referrer: request.referrer,
 							integrity: request.integrity,
-						});
+						};
+
+						const newRequest = new Request(newUrl, requestInit);
 
 						// TODO: why not working?
 						// fetchMock.dontMockOnce();


### PR DESCRIPTION
Fix gateway handling for streamed mutation requests and unavailable fragment endpoints.

- add duplex: 'half' when the node adapter forwards non-GET/HEAD request bodies so streamed PATCH/DELETE requests work correctly in Node
- route non-document fragment fetch failures through onSsrFetchError so hosts can return a fallback response instead of crashing when a fragment server is unavailable
- add gateway regression coverage for streamed request bodies and non-document fetch error recovery

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```
