### PR TITLE
feat: add skills to repo

### DIFF
--- a/packages/web-fragments/.claude/commands/debug-fragment.md
+++ b/packages/web-fragments/.claude/commands/debug-fragment.md
@@ -1,0 +1,73 @@
+Diagnose a web-fragments issue. The user's description (if any): $ARGUMENTS
+
+Work through each category below. For each check, inspect actual project files — do not guess. Skip categories the user's problem clearly does not relate to.
+
+---
+
+## 1. Fragment does not appear at all
+
+**Gateway routing:**
+- Does the request URL match any `routePatterns`? Patterns use path-to-regexp v6. A common mistake: `/products` does NOT match `/products/123` — use `/products/:_*` to match sub-paths.
+- Is `matchRequestToFragment` being reached? Add `console.log` to the middleware to verify.
+- Is the middleware placed before static file serving? If Express/Connect serves `index.html` before the fragment middleware runs, the gateway never sees the request.
+
+**Fragment endpoint reachability:**
+- Is the `endpoint` URL accessible from the gateway? In local dev, check the port is running.
+- Does the fragment endpoint return a 200 for the route? A 404 or 500 triggers `onSsrFetchError` (or a default error response if that handler is missing).
+- Does the endpoint set `X-Frame-Options: DENY`? This blocks the hidden iframe the gateway uses for isolated JS execution. The gateway detects this but the fragment will silently fail to load.
+
+**Client-side initialization:**
+- Is `initializeWebFragments()` called before any `<web-fragment>` element connects to the DOM?
+- Is the `fragment-id` attribute on `<web-fragment>` an exact case-sensitive match to the `fragmentId` in `registerFragment()`?
+
+---
+
+## 2. Piercing not activating (fragment loads but SSR content is missing on first paint)
+
+- Is `piercing: true` set in `registerFragment()`? It defaults to true, but check for an explicit `false`.
+- Is the request a hard navigation (`sec-fetch-dest: document`)? Piercing only fires on full-page loads, not fetch/XHR.
+- Is HTMLRewriter available? On Node.js, the WASM HTMLRewriter from the `htmlrewriter` package is used. Check it is importable and not throwing.
+- Does the app shell HTML contain a `<web-fragment fragment-id="...">` placeholder on the matching route? Without it, the gateway appends the `<web-fragment-host>` at the end of `<body>` as a fallback — piercing still works but layout may shift.
+- Does the fragment's `endpoint` return HTML with a proper `content-type: text/html` header?
+
+---
+
+## 3. Flash of unstyled content (FOUC) during portaling
+
+- Are `piercingClassNames` defined in `registerFragment()` AND do the corresponding CSS rules exist in `piercingStyles`?
+- The `piercingStyles` selector should target `web-fragment-host[data-piercing="true"]` — this applies before portaling. After portaling, the shadow root takes over.
+- Are external stylesheets loading asynchronously in the fragment? The portaling process preserves `<style>` elements but external `<link rel="stylesheet">` sheets inserted before portaling may not survive in all browsers (known Safari limitation).
+- Is there a visible layout shift because the `<web-fragment>` container has no min-height set? Add a min-height matching the expected fragment height.
+
+---
+
+## 4. Fragment JavaScript not executing / broken behavior
+
+**Reframed context issues:**
+- Is the fragment's entry script a `<script type="module">`? Module scripts are correctly deferred and execute in the reframed iframe context.
+- Is the fragment reading `window.location` and getting the wrong origin? In the reframed context, `window.location` reflects the fragment URL, which is correct. If the fragment is comparing against `window.parent`, that is unexpected — fragments should be self-contained.
+- Is the fragment using `document.querySelector` and finding nothing? Within the reframed iframe context, `document` refers to the iframe document. DOM elements are actually in the main frame's shadow root. Use `window.document` consistently rather than global `document` — the reframed context patches them to be equivalent, but third-party libraries may cache a direct reference.
+- Is a third-party script failing with a `crossOrigin` or `instanceof` error? The reframed context patches global constructors, but some libraries perform identity checks that bypass the patch. This is a known limitation — report it at https://github.com/web-fragments/web-fragments/issues.
+
+**History / navigation:**
+- Is `window.history.pushState` in the fragment navigating only the fragment, not the full page? This is correct behavior — history is shared with the main frame. If the main frame is not responding to the navigation, check that the host SPA's router listens to `popstate` events.
+
+---
+
+## 5. CSP / X-Frame-Options blocking the iframe
+
+- Check the fragment endpoint's response headers for `X-Frame-Options: DENY` or a CSP `frame-ancestors` directive that excludes the gateway origin.
+- The gateway creates a hidden iframe with `src` pointing to the fragment URL. The fragment server must allow framing from the gateway's origin.
+- For `frame-ancestors`, allow `'self'` or the specific gateway origin.
+- The gateway detects `X-Frame-Options: DENY` and logs a warning — check the browser console.
+
+---
+
+## Output
+
+For each failing check, show:
+1. What you found (with file path and line number if applicable)
+2. The specific fix
+3. Whether the fix can be applied automatically (and apply it if yes)
+
+If you cannot determine the root cause from files alone, list the minimal set of `console.log` statements to add to narrow down the problem, and show exactly where to add them.

--- a/packages/web-fragments/.claude/commands/debug-fragment.md
+++ b/packages/web-fragments/.claude/commands/debug-fragment.md
@@ -12,16 +12,19 @@ Work through each category below. For each check, inspect actual project files â
 ## 1. Fragment does not appear at all
 
 **Gateway routing:**
+
 - Does the request URL match any `routePatterns`? Patterns use path-to-regexp v6. A common mistake: `/products` does NOT match `/products/123` â€” use `/products/:_*` to match sub-paths.
 - Is `matchRequestToFragment` being reached? Add `console.log` to the middleware to verify.
 - Is the middleware placed before static file serving? If Express/Connect serves `index.html` before the fragment middleware runs, the gateway never sees the request.
 
 **Fragment endpoint reachability:**
+
 - Is the `endpoint` URL accessible from the gateway? In local dev, check the port is running.
 - Does the fragment endpoint return a 200 for the route? A 404 or 500 triggers `onSsrFetchError` (or a default error response if that handler is missing).
 - Does the endpoint set `X-Frame-Options: DENY`? This blocks the hidden iframe the gateway uses for isolated JS execution. The gateway detects this but the fragment will silently fail to load.
 
 **Client-side initialization:**
+
 - Is `initializeWebFragments()` called before any `<web-fragment>` element connects to the DOM?
 - Is the `fragment-id` attribute on `<web-fragment>` an exact case-sensitive match to the `fragmentId` in `registerFragment()`?
 
@@ -49,12 +52,14 @@ Work through each category below. For each check, inspect actual project files â
 ## 4. Fragment JavaScript not executing / broken behavior
 
 **Reframed context issues:**
+
 - Is the fragment's entry script a `<script type="module">`? Module scripts are correctly deferred and execute in the reframed iframe context.
 - Is the fragment reading `window.location` and getting the wrong origin? In the reframed context, `window.location` reflects the fragment URL, which is correct. If the fragment is comparing against `window.parent`, that is unexpected â€” fragments should be self-contained.
 - Is the fragment using `document.querySelector` and finding nothing? Within the reframed iframe context, `document` refers to the iframe document. DOM elements are actually in the main frame's shadow root. Use `window.document` consistently rather than global `document` â€” the reframed context patches them to be equivalent, but third-party libraries may cache a direct reference.
 - Is a third-party script failing with a `crossOrigin` or `instanceof` error? The reframed context patches global constructors, but some libraries perform identity checks that bypass the patch. This is a known limitation â€” report it at https://github.com/web-fragments/web-fragments/issues.
 
 **History / navigation:**
+
 - Is `window.history.pushState` in the fragment navigating only the fragment, not the full page? This is correct behavior â€” history is shared with the main frame. If the main frame is not responding to the navigation, check that the host SPA's router listens to `popstate` events.
 
 ---
@@ -71,6 +76,7 @@ Work through each category below. For each check, inspect actual project files â
 ## Output
 
 For each failing check, show:
+
 1. What you found (with file path and line number if applicable)
 2. The specific fix
 3. Whether the fix can be applied automatically (and apply it if yes)

--- a/packages/web-fragments/.claude/commands/debug-fragment.md
+++ b/packages/web-fragments/.claude/commands/debug-fragment.md
@@ -1,3 +1,8 @@
+---
+name: debug-fragment
+description: Diagnose a web-fragments issue — covers invisible fragments, broken piercing, FOUC, JS isolation failures, and CSP/iframe blocks.
+---
+
 Diagnose a web-fragments issue. The user's description (if any): $ARGUMENTS
 
 Work through each category below. For each check, inspect actual project files — do not guess. Skip categories the user's problem clearly does not relate to.

--- a/packages/web-fragments/.claude/commands/fragment-csp.md
+++ b/packages/web-fragments/.claude/commands/fragment-csp.md
@@ -1,0 +1,61 @@
+Generate or audit Content Security Policy headers for a web-fragments setup. Context: $ARGUMENTS
+
+## How web-fragments uses iframes
+
+The gateway creates a hidden iframe with `src` pointing to the fragment URL to provide an isolated JS execution context. This means:
+- The gateway origin must be allowed to frame the fragment origin (`frame-ancestors`)
+- Fragment endpoints must NOT set `X-Frame-Options: DENY` or `frame-ancestors 'none'`
+- The gateway detects `X-Frame-Options: DENY` and logs a warning — the fragment will silently fail
+
+## Step 1 — Find existing CSP configuration
+
+Search for:
+- `Content-Security-Policy` headers in middleware, Worker responses, or `_headers` files
+- `X-Frame-Options` headers on fragment endpoints
+- `<meta http-equiv="Content-Security-Policy">` in HTML files
+
+## Step 2 — Audit for web-fragments compatibility
+
+For each fragment endpoint, check for:
+
+**Blockers (break the iframe):**
+- `X-Frame-Options: DENY` — change to `SAMEORIGIN` or remove
+- `Content-Security-Policy: frame-ancestors 'none'` — add the gateway origin
+
+**Required allowances:**
+- `frame-ancestors 'self' <gateway-origin>` — allows the gateway to iframe the fragment
+- If the fragment loads scripts from CDNs, ensure `script-src` includes those origins
+- If the fragment uses inline scripts (common with SSR frameworks), ensure `script-src` includes `'unsafe-inline'` or proper nonces
+
+**Note on `iframeHeaders`:** The `iframeHeaders` field in `registerFragment()` sets headers on the iframe *stub* response (the tiny document returned when `sec-fetch-dest: iframe`), not on the fragment content response itself.
+
+## Step 3 — Generate recommended headers
+
+For the **gateway / host app shell**:
+```
+Content-Security-Policy:
+  default-src 'self';
+  script-src 'self' 'unsafe-inline';
+  frame-src 'self' <fragment-origin>;
+```
+
+For each **fragment endpoint**:
+```
+Content-Security-Policy: frame-ancestors 'self' <gateway-origin>;
+```
+
+For **Cloudflare Pages** (`public/_headers` file):
+```
+/<fragment-route>/*
+  Content-Security-Policy: frame-ancestors 'self' <gateway-origin>
+  X-Frame-Options: ALLOWALL
+```
+
+## Step 4 — Apply fixes
+
+Apply fixes directly using the Edit tool:
+- For Node/Express: modify the response headers middleware
+- For Cloudflare Workers: modify the Response constructor in the fetch handler
+- For `_headers` files: edit directly
+
+Report what changed and verify no other CSP directives were inadvertently tightened.

--- a/packages/web-fragments/.claude/commands/fragment-csp.md
+++ b/packages/web-fragments/.claude/commands/fragment-csp.md
@@ -1,3 +1,8 @@
+---
+name: fragment-csp
+description: Generate or audit Content Security Policy headers for a web-fragments setup — ensures the iframe isolation model is not blocked by X-Frame-Options or frame-ancestors directives.
+---
+
 Generate or audit Content Security Policy headers for a web-fragments setup. Context: $ARGUMENTS
 
 ## How web-fragments uses iframes

--- a/packages/web-fragments/.claude/commands/fragment-csp.md
+++ b/packages/web-fragments/.claude/commands/fragment-csp.md
@@ -8,6 +8,7 @@ Generate or audit Content Security Policy headers for a web-fragments setup. Con
 ## How web-fragments uses iframes
 
 The gateway creates a hidden iframe with `src` pointing to the fragment URL to provide an isolated JS execution context. This means:
+
 - The gateway origin must be allowed to frame the fragment origin (`frame-ancestors`)
 - Fragment endpoints must NOT set `X-Frame-Options: DENY` or `frame-ancestors 'none'`
 - The gateway detects `X-Frame-Options: DENY` and logs a warning — the fragment will silently fail
@@ -15,6 +16,7 @@ The gateway creates a hidden iframe with `src` pointing to the fragment URL to p
 ## Step 1 — Find existing CSP configuration
 
 Search for:
+
 - `Content-Security-Policy` headers in middleware, Worker responses, or `_headers` files
 - `X-Frame-Options` headers on fragment endpoints
 - `<meta http-equiv="Content-Security-Policy">` in HTML files
@@ -24,19 +26,22 @@ Search for:
 For each fragment endpoint, check for:
 
 **Blockers (break the iframe):**
+
 - `X-Frame-Options: DENY` — change to `SAMEORIGIN` or remove
 - `Content-Security-Policy: frame-ancestors 'none'` — add the gateway origin
 
 **Required allowances:**
+
 - `frame-ancestors 'self' <gateway-origin>` — allows the gateway to iframe the fragment
 - If the fragment loads scripts from CDNs, ensure `script-src` includes those origins
 - If the fragment uses inline scripts (common with SSR frameworks), ensure `script-src` includes `'unsafe-inline'` or proper nonces
 
-**Note on `iframeHeaders`:** The `iframeHeaders` field in `registerFragment()` sets headers on the iframe *stub* response (the tiny document returned when `sec-fetch-dest: iframe`), not on the fragment content response itself.
+**Note on `iframeHeaders`:** The `iframeHeaders` field in `registerFragment()` sets headers on the iframe _stub_ response (the tiny document returned when `sec-fetch-dest: iframe`), not on the fragment content response itself.
 
 ## Step 3 — Generate recommended headers
 
 For the **gateway / host app shell**:
+
 ```
 Content-Security-Policy:
   default-src 'self';
@@ -45,11 +50,13 @@ Content-Security-Policy:
 ```
 
 For each **fragment endpoint**:
+
 ```
 Content-Security-Policy: frame-ancestors 'self' <gateway-origin>;
 ```
 
 For **Cloudflare Pages** (`public/_headers` file):
+
 ```
 /<fragment-route>/*
   Content-Security-Policy: frame-ancestors 'self' <gateway-origin>
@@ -59,6 +66,7 @@ For **Cloudflare Pages** (`public/_headers` file):
 ## Step 4 — Apply fixes
 
 Apply fixes directly using the Edit tool:
+
 - For Node/Express: modify the response headers middleware
 - For Cloudflare Workers: modify the Response constructor in the fetch handler
 - For `_headers` files: edit directly

--- a/packages/web-fragments/.claude/commands/fragment-perf.md
+++ b/packages/web-fragments/.claude/commands/fragment-perf.md
@@ -39,6 +39,7 @@ Piercing embeds fragment HTML into the app shell response server-side, eliminati
 ## Output
 
 For each issue:
+
 1. Severity: **High** (user-visible regression) / **Medium** (latency increase) / **Low** (optimization opportunity)
 2. What was found (with file path and line number)
 3. The specific fix

--- a/packages/web-fragments/.claude/commands/fragment-perf.md
+++ b/packages/web-fragments/.claude/commands/fragment-perf.md
@@ -1,3 +1,8 @@
+---
+name: fragment-perf
+description: Audit a web-fragments setup for performance issues — checks piercing config, streaming, caching, route pattern specificity, and production mode.
+---
+
 Audit this web-fragments setup for performance issues. Context: $ARGUMENTS
 
 Read the gateway configuration and fragment endpoint code, then check each category.

--- a/packages/web-fragments/.claude/commands/fragment-perf.md
+++ b/packages/web-fragments/.claude/commands/fragment-perf.md
@@ -1,0 +1,41 @@
+Audit this web-fragments setup for performance issues. Context: $ARGUMENTS
+
+Read the gateway configuration and fragment endpoint code, then check each category.
+
+## 1. Piercing
+
+Piercing embeds fragment HTML into the app shell response server-side, eliminating the client-side round-trip on first load. It is the primary performance feature.
+
+- [ ] Is `piercing: true` set (or defaulted) for high-traffic entry-point routes? If any has `piercing: false`, explain the cost.
+- [ ] Does the app shell HTML include `<web-fragment fragment-id="...">` on matching routes? Without the placeholder, the gateway appends the fragment at end of `<body>` — piercing still works but the fragment may appear out of place.
+- [ ] Is `piercingStyles` set with positioning rules for `web-fragment-host[data-piercing="true"]`? Without it, the pre-pierced fragment may appear in the wrong position, causing layout shift (CLS).
+
+## 2. Streaming
+
+- [ ] Is the gateway running on Cloudflare Workers with native HTMLRewriter? Native HTMLRewriter streams the combined response before the fragment fetch completes. The WASM HTMLRewriter (Node.js) must buffer the entire fragment first — flag this as a latency limitation.
+- [ ] Does the fragment endpoint stream its response? Frameworks like Remix and Qwik City support streaming SSR. Confirm the fragment is not buffering before sending.
+
+## 3. Caching
+
+- [ ] Does the fragment endpoint set `Cache-Control` headers? Without caching, every hard navigation fetches the fragment fresh.
+- [ ] Are fragment cache headers forwarded to the combined response via `forwardFragmentHeaders: ['cache-control']`? Without this, the host's cache headers are used instead.
+- [ ] The gateway sets `Vary: sec-fetch-dest` on all responses to prevent BFCache issues — verify no proxy is stripping this header.
+- [ ] The iframe stub is cached for 1 hour by default (`max-age=3600, stale-while-revalidate=31536000`). Only flag if `iframeHeaders` is overriding it with a shorter TTL.
+
+## 4. Route pattern specificity
+
+- [ ] Are any `routePatterns` overly broad (e.g. `/:_*` catching everything)? This causes the gateway to attempt fragment fetches for routes that should fall through to the app shell.
+- [ ] If multiple fragments are registered, do their patterns overlap? The gateway matches the first pattern found. More specific patterns should be listed first. (This is a known TODO in `fragment-gateway.ts`.)
+
+## 5. Production mode
+
+- [ ] Is `mode` set to `'production'` in deployed environments? Development mode disables compression passthrough for Miniflare compatibility (cloudflare/workers-sdk#6577) and emits verbose error responses — both are wrong for production.
+
+## Output
+
+For each issue:
+1. Severity: **High** (user-visible regression) / **Medium** (latency increase) / **Low** (optimization opportunity)
+2. What was found (with file path and line number)
+3. The specific fix
+
+Apply low-risk fixes automatically (wrong `mode`, missing `forwardFragmentHeaders`). Ask before structural changes.

--- a/packages/web-fragments/.claude/commands/fragment-test.md
+++ b/packages/web-fragments/.claude/commands/fragment-test.md
@@ -1,0 +1,94 @@
+Generate a Playwright test for a web-fragment scenario. Scenario: $ARGUMENTS
+
+Web-fragments tests use three files per scenario under `test/playground/<scenario-name>/`:
+- `index.html` — host page with `<web-fragment>`
+- `fragment.html` — fragment HTML served by Vite
+- `spec.ts` — Playwright test file
+
+Generate all three. Ask for `fragmentId` and scenario name if not in $ARGUMENTS, then write to disk.
+
+## spec.ts pattern
+
+```ts
+import { test, expect } from '@playwright/test';
+import { failOnBrowserErrors, getFragmentContext } from '../playwright.utils';
+
+const { beforeEach, describe } = test;
+
+beforeEach(failOnBrowserErrors);
+
+describe('<scenario-name>', () => {
+  beforeEach(async ({ page }) => {
+    await page.goto('/<scenario-name>/');
+  });
+
+  test('fragment renders', async ({ page }) => {
+    const fragment = page.locator('web-fragment[fragment-id="<fragmentId>"]');
+    await expect(fragment).toBeVisible();
+    await expect(fragment.getByRole('heading')).toHaveText('<expected heading>');
+  });
+
+  test('DOM is isolated from host', async ({ page }) => {
+    await expect(page.locator('#host-element')).not.toHaveCSS('color', 'rgb(255, 0, 0)');
+  });
+
+  test('JS runs in isolated context', async ({ page }) => {
+    const fragmentHost = page.locator('web-fragment[fragment-id="<fragmentId>"] web-fragment-host');
+    // getFragmentContext returns the Playwright Frame for the reframed iframe execution context
+    const ctx = await getFragmentContext(fragmentHost);
+    expect(await ctx.evaluate(() => document.title)).toBe('<fragmentId> fragment');
+  });
+});
+
+// Piercing tests — only run when PIERCING env var is not 'false'
+process.env.PIERCING !== 'false' &&
+  describe('piercing', () => {
+    test('fragment host is pre-pierced on hard navigation', async ({ page }) => {
+      await expect(page.locator('web-fragment-host[data-piercing="true"]')).toBeAttached();
+    });
+
+    test('styles are preserved after portaling', async ({ page }) => {
+      const fragmentHost = page.locator('web-fragment-host');
+      await page.locator('button#portal-fragment').click();
+      await expect(fragmentHost.locator('h2')).toBeVisible();
+    });
+  });
+```
+
+## index.html pattern
+
+```html
+<!doctype html>
+<html>
+  <head><meta charset="UTF-8" /><title>Host App</title></head>
+  <body>
+    <div id="host-element">Host content</div>
+    <web-fragment fragment-id="<fragmentId>" src="/<scenario-name>/fragment.html"></web-fragment>
+    <script type="module">
+      import { initializeWebFragments } from '/src/elements/index.ts';
+      initializeWebFragments();
+    </script>
+  </body>
+</html>
+```
+
+## fragment.html pattern
+
+```html
+<!doctype html>
+<html>
+  <head><meta charset="UTF-8" /><title><fragmentId> fragment</title></head>
+  <body>
+    <div data-testid="fragment-inner"><h2>Fragment heading</h2></div>
+    <script type="module">console.log('fragment loaded');</script>
+  </body>
+</html>
+```
+
+## Rules
+
+- `failOnBrowserErrors` in `beforeEach` is required — it surfaces console errors that are otherwise swallowed.
+- `getFragmentContext(hostLocator)` returns a Playwright `Frame` for `evaluate()` inside the reframed JS context.
+- Scope locators to `fragment.locator(...)` to reach inside the shadow root rather than `page.locator(...)`.
+- Prefer `toHaveText`, `toBeVisible`, `toHaveCSS` over `evaluate` — they auto-retry.
+- `PIERCING` env var is set by `test:playground:pierced` / `test:playground:nonpierced` npm scripts.

--- a/packages/web-fragments/.claude/commands/fragment-test.md
+++ b/packages/web-fragments/.claude/commands/fragment-test.md
@@ -1,3 +1,8 @@
+---
+name: fragment-test
+description: Generate a Playwright test scenario for a web-fragment — produces index.html, fragment.html, and spec.ts following the playground test harness pattern.
+---
+
 Generate a Playwright test for a web-fragment scenario. Scenario: $ARGUMENTS
 
 Web-fragments tests use three files per scenario under `test/playground/<scenario-name>/`:

--- a/packages/web-fragments/.claude/commands/fragment-test.md
+++ b/packages/web-fragments/.claude/commands/fragment-test.md
@@ -6,6 +6,7 @@ description: Generate a Playwright test scenario for a web-fragment — produces
 Generate a Playwright test for a web-fragment scenario. Scenario: $ARGUMENTS
 
 Web-fragments tests use three files per scenario under `test/playground/<scenario-name>/`:
+
 - `index.html` — host page with `<web-fragment>`
 - `fragment.html` — fragment HTML served by Vite
 - `spec.ts` — Playwright test file
@@ -23,41 +24,41 @@ const { beforeEach, describe } = test;
 beforeEach(failOnBrowserErrors);
 
 describe('<scenario-name>', () => {
-  beforeEach(async ({ page }) => {
-    await page.goto('/<scenario-name>/');
-  });
+	beforeEach(async ({ page }) => {
+		await page.goto('/<scenario-name>/');
+	});
 
-  test('fragment renders', async ({ page }) => {
-    const fragment = page.locator('web-fragment[fragment-id="<fragmentId>"]');
-    await expect(fragment).toBeVisible();
-    await expect(fragment.getByRole('heading')).toHaveText('<expected heading>');
-  });
+	test('fragment renders', async ({ page }) => {
+		const fragment = page.locator('web-fragment[fragment-id="<fragmentId>"]');
+		await expect(fragment).toBeVisible();
+		await expect(fragment.getByRole('heading')).toHaveText('<expected heading>');
+	});
 
-  test('DOM is isolated from host', async ({ page }) => {
-    await expect(page.locator('#host-element')).not.toHaveCSS('color', 'rgb(255, 0, 0)');
-  });
+	test('DOM is isolated from host', async ({ page }) => {
+		await expect(page.locator('#host-element')).not.toHaveCSS('color', 'rgb(255, 0, 0)');
+	});
 
-  test('JS runs in isolated context', async ({ page }) => {
-    const fragmentHost = page.locator('web-fragment[fragment-id="<fragmentId>"] web-fragment-host');
-    // getFragmentContext returns the Playwright Frame for the reframed iframe execution context
-    const ctx = await getFragmentContext(fragmentHost);
-    expect(await ctx.evaluate(() => document.title)).toBe('<fragmentId> fragment');
-  });
+	test('JS runs in isolated context', async ({ page }) => {
+		const fragmentHost = page.locator('web-fragment[fragment-id="<fragmentId>"] web-fragment-host');
+		// getFragmentContext returns the Playwright Frame for the reframed iframe execution context
+		const ctx = await getFragmentContext(fragmentHost);
+		expect(await ctx.evaluate(() => document.title)).toBe('<fragmentId> fragment');
+	});
 });
 
 // Piercing tests — only run when PIERCING env var is not 'false'
 process.env.PIERCING !== 'false' &&
-  describe('piercing', () => {
-    test('fragment host is pre-pierced on hard navigation', async ({ page }) => {
-      await expect(page.locator('web-fragment-host[data-piercing="true"]')).toBeAttached();
-    });
+	describe('piercing', () => {
+		test('fragment host is pre-pierced on hard navigation', async ({ page }) => {
+			await expect(page.locator('web-fragment-host[data-piercing="true"]')).toBeAttached();
+		});
 
-    test('styles are preserved after portaling', async ({ page }) => {
-      const fragmentHost = page.locator('web-fragment-host');
-      await page.locator('button#portal-fragment').click();
-      await expect(fragmentHost.locator('h2')).toBeVisible();
-    });
-  });
+		test('styles are preserved after portaling', async ({ page }) => {
+			const fragmentHost = page.locator('web-fragment-host');
+			await page.locator('button#portal-fragment').click();
+			await expect(fragmentHost.locator('h2')).toBeVisible();
+		});
+	});
 ```
 
 ## index.html pattern
@@ -65,15 +66,18 @@ process.env.PIERCING !== 'false' &&
 ```html
 <!doctype html>
 <html>
-  <head><meta charset="UTF-8" /><title>Host App</title></head>
-  <body>
-    <div id="host-element">Host content</div>
-    <web-fragment fragment-id="<fragmentId>" src="/<scenario-name>/fragment.html"></web-fragment>
-    <script type="module">
-      import { initializeWebFragments } from '/src/elements/index.ts';
-      initializeWebFragments();
-    </script>
-  </body>
+	<head>
+		<meta charset="UTF-8" />
+		<title>Host App</title>
+	</head>
+	<body>
+		<div id="host-element">Host content</div>
+		<web-fragment fragment-id="<fragmentId>" src="/<scenario-name>/fragment.html"></web-fragment>
+		<script type="module">
+			import { initializeWebFragments } from '/src/elements/index.ts';
+			initializeWebFragments();
+		</script>
+	</body>
 </html>
 ```
 
@@ -82,11 +86,16 @@ process.env.PIERCING !== 'false' &&
 ```html
 <!doctype html>
 <html>
-  <head><meta charset="UTF-8" /><title><fragmentId> fragment</title></head>
-  <body>
-    <div data-testid="fragment-inner"><h2>Fragment heading</h2></div>
-    <script type="module">console.log('fragment loaded');</script>
-  </body>
+	<head>
+		<meta charset="UTF-8" />
+		<title><fragmentId> fragment</title>
+	</head>
+	<body>
+		<div data-testid="fragment-inner"><h2>Fragment heading</h2></div>
+		<script type="module">
+			console.log('fragment loaded');
+		</script>
+	</body>
 </html>
 ```
 

--- a/packages/web-fragments/.claude/commands/gateway-config.md
+++ b/packages/web-fragments/.claude/commands/gateway-config.md
@@ -1,3 +1,8 @@
+---
+name: gateway-config
+description: Review or generate a FragmentGateway configuration — flags deprecated fields, missing error handlers, and middleware ordering issues.
+---
+
 Review or generate the FragmentGateway configuration for this project. Arguments: $ARGUMENTS
 
 ## What to do

--- a/packages/web-fragments/.claude/commands/gateway-config.md
+++ b/packages/web-fragments/.claude/commands/gateway-config.md
@@ -1,0 +1,53 @@
+Review or generate the FragmentGateway configuration for this project. Arguments: $ARGUMENTS
+
+## What to do
+
+Search the project for existing gateway configuration:
+- Look for `new FragmentGateway(` calls
+- Look for `registerFragment(` calls
+- Look for `getWebMiddleware(` or `getNodeMiddleware(` calls
+- Look for Cloudflare Workers entry points (`export default { fetch`) or Express/Connect server files
+
+If no gateway exists, generate one (ask the user which deployment target: Cloudflare Workers/Pages or Node/Express).
+
+## Configuration review checklist
+
+For each registered fragment, check and flag:
+
+**Required fields:**
+- [ ] `fragmentId` is present and unique across all registrations
+- [ ] `routePatterns` is non-empty and uses valid path-to-regexp v6 syntax (e.g. `/path/:param`, `/path/:_*` for catch-all)
+- [ ] `endpoint` is set (not the deprecated `upstream`)
+
+**Deprecated fields (warn and suggest migration):**
+- `upstream` → rename to `endpoint`
+- `prePiercingClassNames` → rename to `piercingClassNames`
+- `prePiercingStyles` on `FragmentGatewayConfig` → rename to `piercingStyles`
+
+**Header forwarding:**
+- [ ] If the fragment sets response headers that the host app needs (e.g. `Cache-Control`, custom fragment headers, `Set-Cookie`), they must be listed in `forwardFragmentHeaders`
+- [ ] `iframeHeaders` is only needed for custom auth or tracing headers on the iframe stub request
+
+**SSR error handling:**
+- [ ] `onSsrFetchError` is present — without it, a fragment fetch failure returns a generic 500 to the end user
+- [ ] The returned `response` has `content-type: text/html`
+- [ ] If `overrideResponse: true` is used, the error response replaces the entire page (useful for auth redirects)
+
+**Middleware placement:**
+- [ ] For Express/Connect: `app.use(getNodeMiddleware(...))` must come BEFORE static file middleware and route handlers
+- [ ] For Cloudflare Workers: `getWebMiddleware` wraps the `ASSETS.fetch` call
+- [ ] `mode` is set to `'production'` for deployed environments (disables miniflare workarounds and verbose error responses)
+
+**Piercing styles:**
+- [ ] `piercingStyles` string is valid CSS
+- [ ] The selector targets `web-fragment-host[data-piercing="true"]` for pre-piercing layout (positioning, z-index) so the fragment appears in the correct place before portaling completes
+- [ ] Styles are scoped enough not to affect non-fragment elements
+
+## Output
+
+Report findings as a prioritized list:
+1. **Errors** — things that will definitely break (missing required fields, deprecated fields still in use)
+2. **Warnings** — things that may cause subtle issues (missing `onSsrFetchError`, unscoped piercing styles)
+3. **Suggestions** — optional improvements (adding `forwardFragmentHeaders`, tightening route patterns)
+
+If the user asked to fix issues, apply them directly with the Edit tool. Show a diff summary of what changed.

--- a/packages/web-fragments/.claude/commands/gateway-config.md
+++ b/packages/web-fragments/.claude/commands/gateway-config.md
@@ -8,6 +8,7 @@ Review or generate the FragmentGateway configuration for this project. Arguments
 ## What to do
 
 Search the project for existing gateway configuration:
+
 - Look for `new FragmentGateway(` calls
 - Look for `registerFragment(` calls
 - Look for `getWebMiddleware(` or `getNodeMiddleware(` calls
@@ -20,30 +21,36 @@ If no gateway exists, generate one (ask the user which deployment target: Cloudf
 For each registered fragment, check and flag:
 
 **Required fields:**
+
 - [ ] `fragmentId` is present and unique across all registrations
 - [ ] `routePatterns` is non-empty and uses valid path-to-regexp v6 syntax (e.g. `/path/:param`, `/path/:_*` for catch-all)
 - [ ] `endpoint` is set (not the deprecated `upstream`)
 
 **Deprecated fields (warn and suggest migration):**
+
 - `upstream` → rename to `endpoint`
 - `prePiercingClassNames` → rename to `piercingClassNames`
 - `prePiercingStyles` on `FragmentGatewayConfig` → rename to `piercingStyles`
 
 **Header forwarding:**
+
 - [ ] If the fragment sets response headers that the host app needs (e.g. `Cache-Control`, custom fragment headers, `Set-Cookie`), they must be listed in `forwardFragmentHeaders`
 - [ ] `iframeHeaders` is only needed for custom auth or tracing headers on the iframe stub request
 
 **SSR error handling:**
+
 - [ ] `onSsrFetchError` is present — without it, a fragment fetch failure returns a generic 500 to the end user
 - [ ] The returned `response` has `content-type: text/html`
 - [ ] If `overrideResponse: true` is used, the error response replaces the entire page (useful for auth redirects)
 
 **Middleware placement:**
+
 - [ ] For Express/Connect: `app.use(getNodeMiddleware(...))` must come BEFORE static file middleware and route handlers
 - [ ] For Cloudflare Workers: `getWebMiddleware` wraps the `ASSETS.fetch` call
 - [ ] `mode` is set to `'production'` for deployed environments (disables miniflare workarounds and verbose error responses)
 
 **Piercing styles:**
+
 - [ ] `piercingStyles` string is valid CSS
 - [ ] The selector targets `web-fragment-host[data-piercing="true"]` for pre-piercing layout (positioning, z-index) so the fragment appears in the correct place before portaling completes
 - [ ] Styles are scoped enough not to affect non-fragment elements
@@ -51,6 +58,7 @@ For each registered fragment, check and flag:
 ## Output
 
 Report findings as a prioritized list:
+
 1. **Errors** — things that will definitely break (missing required fields, deprecated fields still in use)
 2. **Warnings** — things that may cause subtle issues (missing `onSsrFetchError`, unscoped piercing styles)
 3. **Suggestions** — optional improvements (adding `forwardFragmentHeaders`, tightening route patterns)

--- a/packages/web-fragments/.claude/commands/init-fragment.md
+++ b/packages/web-fragments/.claude/commands/init-fragment.md
@@ -1,0 +1,109 @@
+Scaffold a new web-fragment end-to-end. Work through the following steps:
+
+1. Ask the user (or infer from $ARGUMENTS) for:
+   - `fragmentId` — a short kebab-case identifier, e.g. `user-profile`
+   - `routePatterns` — one or more path-to-regexp patterns, e.g. `/profile/:userId`, `/profile/:_*`
+   - Deployment target: `cloudflare` (Cloudflare Workers / Pages) or `node` (Express / Connect)
+   - Whether SSR piercing should be enabled (default: yes)
+   - `endpoint` — the fragment's origin URL, e.g. `http://localhost:3001`
+   - `piercingClassNames` — optional CSS class names for pre-piercing styling
+
+2. Generate the **gateway registration** block to add to the user's gateway setup file:
+
+For Cloudflare Workers (`web-middleware`):
+```ts
+import { FragmentGateway } from 'web-fragments/gateway';
+import { getWebMiddleware } from 'web-fragments/gateway';
+
+const gateway = new FragmentGateway({
+  piercingStyles: `
+    <style>
+      web-fragment-host[data-piercing="true"] {
+        position: absolute;
+        z-index: 9999;
+      }
+    </style>
+  `,
+});
+
+gateway.registerFragment({
+  fragmentId: '<fragmentId>',
+  routePatterns: ['<routePattern>'],
+  endpoint: '<endpoint>',
+  piercing: true,
+  piercingClassNames: ['<fragmentId>'],
+  onSsrFetchError: () => ({
+    response: new Response('<p><fragmentId> is unavailable.</p>', {
+      headers: { 'content-type': 'text/html' },
+    }),
+  }),
+});
+
+export default {
+  fetch(request, env, ctx) {
+    return getWebMiddleware(gateway, { mode: 'production' })(request, () =>
+      env.ASSETS.fetch(request),
+    );
+  },
+};
+```
+
+For Node / Express:
+```ts
+import { FragmentGateway } from 'web-fragments/gateway';
+import { getNodeMiddleware } from 'web-fragments/gateway/node';
+
+const gateway = new FragmentGateway({ piercingStyles: '' });
+
+gateway.registerFragment({
+  fragmentId: '<fragmentId>',
+  routePatterns: ['<routePattern>'],
+  endpoint: '<endpoint>',
+  piercing: true,
+  onSsrFetchError: () => ({
+    response: new Response('<p><fragmentId> is unavailable.</p>', {
+      headers: { 'content-type': 'text/html' },
+    }),
+  }),
+});
+
+app.use(getNodeMiddleware(gateway, { mode: 'development' }));
+```
+
+3. Generate the **app shell HTML** placeholder — the `<web-fragment>` element the host app must include on the routes where this fragment appears:
+
+```html
+<web-fragment fragment-id="<fragmentId>" src="/<route>"></web-fragment>
+```
+
+Remind the user that `initializeWebFragments()` from `web-fragments` must be called once in the app shell's client-side entry point:
+```ts
+import { initializeWebFragments } from 'web-fragments';
+initializeWebFragments();
+```
+
+4. Generate a **fragment HTML stub** that the fragment server should return. Emphasize that for piercing to work correctly, `<html>`, `<head>`, and `<body>` tags are preserved (the gateway rewrites them to `<wf-html>`, `<wf-head>`, `<wf-body>` automatically):
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title><fragmentId> fragment</title>
+  </head>
+  <body>
+    <div id="app">
+      <!-- <fragmentId> renders here -->
+    </div>
+    <script type="module" src="/entry.js"></script>
+  </body>
+</html>
+```
+
+5. Remind the user of key caveats:
+   - The gateway middleware must be placed **before** static file serving in the middleware chain.
+   - The fragment endpoint must NOT set `X-Frame-Options: DENY` — the gateway uses a hidden iframe as the isolated JS execution context.
+   - Route patterns follow path-to-regexp v6 syntax. Use `/:_*` to match all sub-paths.
+   - `endpoint` can also be a `fetch`-compatible function for custom routing logic.
+
+Output each generated file as a separate fenced code block labelled with where it belongs. If the user has an existing gateway file open or mentioned, insert the `registerFragment` call into it directly using the Edit tool.

--- a/packages/web-fragments/.claude/commands/init-fragment.md
+++ b/packages/web-fragments/.claude/commands/init-fragment.md
@@ -6,6 +6,7 @@ description: Scaffold a new web-fragment end-to-end — generates gateway regist
 Scaffold a new web-fragment end-to-end. Work through the following steps:
 
 1. Ask the user (or infer from $ARGUMENTS) for:
+
    - `fragmentId` — a short kebab-case identifier, e.g. `user-profile`
    - `routePatterns` — one or more path-to-regexp patterns, e.g. `/profile/:userId`, `/profile/:_*`
    - Deployment target: `cloudflare` (Cloudflare Workers / Pages) or `node` (Express / Connect)
@@ -16,12 +17,13 @@ Scaffold a new web-fragment end-to-end. Work through the following steps:
 2. Generate the **gateway registration** block to add to the user's gateway setup file:
 
 For Cloudflare Workers (`web-middleware`):
+
 ```ts
 import { FragmentGateway } from 'web-fragments/gateway';
 import { getWebMiddleware } from 'web-fragments/gateway';
 
 const gateway = new FragmentGateway({
-  piercingStyles: `
+	piercingStyles: `
     <style>
       web-fragment-host[data-piercing="true"] {
         position: absolute;
@@ -32,28 +34,27 @@ const gateway = new FragmentGateway({
 });
 
 gateway.registerFragment({
-  fragmentId: '<fragmentId>',
-  routePatterns: ['<routePattern>'],
-  endpoint: '<endpoint>',
-  piercing: true,
-  piercingClassNames: ['<fragmentId>'],
-  onSsrFetchError: () => ({
-    response: new Response('<p><fragmentId> is unavailable.</p>', {
-      headers: { 'content-type': 'text/html' },
-    }),
-  }),
+	fragmentId: '<fragmentId>',
+	routePatterns: ['<routePattern>'],
+	endpoint: '<endpoint>',
+	piercing: true,
+	piercingClassNames: ['<fragmentId>'],
+	onSsrFetchError: () => ({
+		response: new Response('<p><fragmentId> is unavailable.</p>', {
+			headers: { 'content-type': 'text/html' },
+		}),
+	}),
 });
 
 export default {
-  fetch(request, env, ctx) {
-    return getWebMiddleware(gateway, { mode: 'production' })(request, () =>
-      env.ASSETS.fetch(request),
-    );
-  },
+	fetch(request, env, ctx) {
+		return getWebMiddleware(gateway, { mode: 'production' })(request, () => env.ASSETS.fetch(request));
+	},
 };
 ```
 
 For Node / Express:
+
 ```ts
 import { FragmentGateway } from 'web-fragments/gateway';
 import { getNodeMiddleware } from 'web-fragments/gateway/node';
@@ -61,15 +62,15 @@ import { getNodeMiddleware } from 'web-fragments/gateway/node';
 const gateway = new FragmentGateway({ piercingStyles: '' });
 
 gateway.registerFragment({
-  fragmentId: '<fragmentId>',
-  routePatterns: ['<routePattern>'],
-  endpoint: '<endpoint>',
-  piercing: true,
-  onSsrFetchError: () => ({
-    response: new Response('<p><fragmentId> is unavailable.</p>', {
-      headers: { 'content-type': 'text/html' },
-    }),
-  }),
+	fragmentId: '<fragmentId>',
+	routePatterns: ['<routePattern>'],
+	endpoint: '<endpoint>',
+	piercing: true,
+	onSsrFetchError: () => ({
+		response: new Response('<p><fragmentId> is unavailable.</p>', {
+			headers: { 'content-type': 'text/html' },
+		}),
+	}),
 });
 
 app.use(getNodeMiddleware(gateway, { mode: 'development' }));
@@ -82,6 +83,7 @@ app.use(getNodeMiddleware(gateway, { mode: 'development' }));
 ```
 
 Remind the user that `initializeWebFragments()` from `web-fragments` must be called once in the app shell's client-side entry point:
+
 ```ts
 import { initializeWebFragments } from 'web-fragments';
 initializeWebFragments();
@@ -92,16 +94,16 @@ initializeWebFragments();
 ```html
 <!doctype html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <title><fragmentId> fragment</title>
-  </head>
-  <body>
-    <div id="app">
-      <!-- <fragmentId> renders here -->
-    </div>
-    <script type="module" src="/entry.js"></script>
-  </body>
+	<head>
+		<meta charset="UTF-8" />
+		<title><fragmentId> fragment</title>
+	</head>
+	<body>
+		<div id="app">
+			<!-- <fragmentId> renders here -->
+		</div>
+		<script type="module" src="/entry.js"></script>
+	</body>
 </html>
 ```
 

--- a/packages/web-fragments/.claude/commands/init-fragment.md
+++ b/packages/web-fragments/.claude/commands/init-fragment.md
@@ -1,3 +1,8 @@
+---
+name: init-fragment
+description: Scaffold a new web-fragment end-to-end — generates gateway registration, app shell placeholder, and fragment HTML stub.
+---
+
 Scaffold a new web-fragment end-to-end. Work through the following steps:
 
 1. Ask the user (or infer from $ARGUMENTS) for:

--- a/packages/web-fragments/.claude/commands/migrate-to-fragments.md
+++ b/packages/web-fragments/.claude/commands/migrate-to-fragments.md
@@ -1,0 +1,87 @@
+Analyze this project and produce a web-fragments migration plan. Context: $ARGUMENTS
+
+## Step 1 — Understand the current architecture
+
+Read the project files to determine:
+- Is this a monolithic SSR app, a SPA, or a mix?
+- What server framework is in use (Express, Fastify, Cloudflare Workers, Next.js, Remix, etc.)?
+- What frontend framework is in use (React, Vue, Angular, vanilla, etc.)?
+- Are there distinct "sections" that could be independently deployed (admin panel, user profile, checkout)?
+- What is the current routing structure?
+
+## Step 2 — Identify fragment candidates
+
+A good fragment candidate:
+- Has distinct ownership (different team, different release cadence)
+- Has a bounded URL namespace (e.g. `/account/`, `/checkout/`, `/admin/`)
+- Does NOT share mutable client-side state with other sections (read-only shared state like user identity is fine)
+- Can be independently built and deployed
+
+List each candidate with:
+- Proposed `fragmentId`
+- Proposed `routePatterns` (path-to-regexp v6 syntax, e.g. `/account/:_*`)
+- Current location in the monolith
+- Extraction complexity: low / medium / high
+- Key dependencies to untangle
+
+## Step 3 — Propose gateway placement
+
+Determine where the `FragmentGateway` middleware should live:
+- **Cloudflare Workers/Pages**: a `functions/_middleware.ts` or dedicated Worker
+- **Express/Connect**: middleware added before static file serving
+- **Next.js / Remix**: a separate gateway proxy in front of the app
+
+Gateway stub for **Express**:
+```ts
+import { FragmentGateway } from 'web-fragments/gateway';
+import { getNodeMiddleware } from 'web-fragments/gateway/node';
+
+const gateway = new FragmentGateway({ piercingStyles: '' });
+// gateway.registerFragment(...) calls go here
+
+app.use(getNodeMiddleware(gateway, { mode: 'development' }));
+// static file serving must come AFTER this middleware
+```
+
+Gateway stub for **Cloudflare Workers**:
+```ts
+import { FragmentGateway } from 'web-fragments/gateway';
+import { getWebMiddleware } from 'web-fragments/gateway';
+
+const gateway = new FragmentGateway({ piercingStyles: '' });
+
+export default {
+  fetch(request, env, ctx) {
+    return getWebMiddleware(gateway, { mode: 'production' })(request, () =>
+      env.ASSETS.fetch(request),
+    );
+  },
+};
+```
+
+## Step 4 — Phased migration plan
+
+Order fragments by extraction complexity (low first). For each fragment:
+
+1. Register route patterns in the gateway pointing to the current monolith (no isolation yet)
+2. Add `<web-fragment fragment-id="...">` placeholder to the host app shell on matching routes
+3. Call `initializeWebFragments()` in the host app's client entry point
+4. Extract the fragment to its own deployable unit
+5. Update `endpoint` in gateway registration to point to the new service
+6. Enable piercing and add `piercingStyles` for layout continuity
+7. Write Playwright tests using the `/fragment-test` skill
+
+## Step 5 — Shared state risks
+
+List any global client-side state (Redux, Zustand, `window.*` globals, global CSS variables) currently shared across sections being extracted. For each, explain the risk and suggest a replacement: URL params, custom events, shared API calls, or pub/sub between fragments.
+
+## Output
+
+Produce a markdown document with:
+- Architecture summary (2-3 sentences)
+- Fragment candidate table: fragmentId | routePatterns | complexity | owner
+- Gateway placement recommendation with code
+- Phased plan as a numbered checklist
+- Shared state risks section
+
+Do not modify any files unless the user explicitly asks to apply a specific step.

--- a/packages/web-fragments/.claude/commands/migrate-to-fragments.md
+++ b/packages/web-fragments/.claude/commands/migrate-to-fragments.md
@@ -8,6 +8,7 @@ Analyze this project and produce a web-fragments migration plan. Context: $ARGUM
 ## Step 1 — Understand the current architecture
 
 Read the project files to determine:
+
 - Is this a monolithic SSR app, a SPA, or a mix?
 - What server framework is in use (Express, Fastify, Cloudflare Workers, Next.js, Remix, etc.)?
 - What frontend framework is in use (React, Vue, Angular, vanilla, etc.)?
@@ -17,12 +18,14 @@ Read the project files to determine:
 ## Step 2 — Identify fragment candidates
 
 A good fragment candidate:
+
 - Has distinct ownership (different team, different release cadence)
 - Has a bounded URL namespace (e.g. `/account/`, `/checkout/`, `/admin/`)
 - Does NOT share mutable client-side state with other sections (read-only shared state like user identity is fine)
 - Can be independently built and deployed
 
 List each candidate with:
+
 - Proposed `fragmentId`
 - Proposed `routePatterns` (path-to-regexp v6 syntax, e.g. `/account/:_*`)
 - Current location in the monolith
@@ -32,11 +35,13 @@ List each candidate with:
 ## Step 3 — Propose gateway placement
 
 Determine where the `FragmentGateway` middleware should live:
+
 - **Cloudflare Workers/Pages**: a `functions/_middleware.ts` or dedicated Worker
 - **Express/Connect**: middleware added before static file serving
 - **Next.js / Remix**: a separate gateway proxy in front of the app
 
 Gateway stub for **Express**:
+
 ```ts
 import { FragmentGateway } from 'web-fragments/gateway';
 import { getNodeMiddleware } from 'web-fragments/gateway/node';
@@ -49,6 +54,7 @@ app.use(getNodeMiddleware(gateway, { mode: 'development' }));
 ```
 
 Gateway stub for **Cloudflare Workers**:
+
 ```ts
 import { FragmentGateway } from 'web-fragments/gateway';
 import { getWebMiddleware } from 'web-fragments/gateway';
@@ -56,11 +62,9 @@ import { getWebMiddleware } from 'web-fragments/gateway';
 const gateway = new FragmentGateway({ piercingStyles: '' });
 
 export default {
-  fetch(request, env, ctx) {
-    return getWebMiddleware(gateway, { mode: 'production' })(request, () =>
-      env.ASSETS.fetch(request),
-    );
-  },
+	fetch(request, env, ctx) {
+		return getWebMiddleware(gateway, { mode: 'production' })(request, () => env.ASSETS.fetch(request));
+	},
 };
 ```
 
@@ -83,6 +87,7 @@ List any global client-side state (Redux, Zustand, `window.*` globals, global CS
 ## Output
 
 Produce a markdown document with:
+
 - Architecture summary (2-3 sentences)
 - Fragment candidate table: fragmentId | routePatterns | complexity | owner
 - Gateway placement recommendation with code

--- a/packages/web-fragments/.claude/commands/migrate-to-fragments.md
+++ b/packages/web-fragments/.claude/commands/migrate-to-fragments.md
@@ -1,3 +1,8 @@
+---
+name: migrate-to-fragments
+description: Analyze an existing app and produce a phased web-fragments migration plan — identifies fragment candidates, gateway placement, and shared state risks.
+---
+
 Analyze this project and produce a web-fragments migration plan. Context: $ARGUMENTS
 
 ## Step 1 — Understand the current architecture

--- a/packages/web-fragments/README.md
+++ b/packages/web-fragments/README.md
@@ -48,6 +48,22 @@ The best way to learn more is going to [our official documentation](https://web-
 
 You can also check out the [demos present in this repository](./e2e/) where you can find examples [e2e/pierced-react/README.md](./e2e/pierced-react/README.md) for platforms supporting [Web Fetch API](https://developer.mozilla.org/docs/Web/API/Fetch_API) like Cloudflare or Netlify, or [e2e/node-servers/README.md](./e2e/node-servers/README.md) for platforms supporting Node.js runtimes.
 
+## Claude Code skills
+
+If you use [Claude Code](https://claude.ai/code), installing this package automatically links a set of slash commands into your project's `.claude/commands/web-fragments/` directory via a postinstall script.
+
+| Command | What it does |
+|---|---|
+| `/web-fragments:init-fragment` | Scaffolds gateway registration, app shell placeholder, and fragment HTML for a new fragment |
+| `/web-fragments:gateway-config` | Reviews or generates your `FragmentGateway` configuration and flags deprecated fields or missing error handlers |
+| `/web-fragments:debug-fragment` | Systematic diagnostic for invisible fragments, broken piercing, FOUC, and CSP/iframe blocks |
+| `/web-fragments:fragment-test` | Generates a Playwright test scenario (`index.html` + `fragment.html` + `spec.ts`) |
+| `/web-fragments:migrate-to-fragments` | Analyzes an existing app and produces a phased extraction plan |
+| `/web-fragments:fragment-csp` | Generates and audits Content Security Policy headers for the iframe-based isolation model |
+| `/web-fragments:fragment-perf` | Audits your setup for piercing, streaming, caching, and route pattern issues |
+
+The commands are discovered automatically — no manual setup required beyond having Claude Code installed.
+
 ## More resources
 
 We blogged about the philosophy of our approach and published some early research on the Cloudflare blog. You can check out a post introducing the previous generation of Web Fragments: https://blog.cloudflare.com/better-micro-frontends.

--- a/packages/web-fragments/README.md
+++ b/packages/web-fragments/README.md
@@ -52,15 +52,15 @@ You can also check out the [demos present in this repository](./e2e/) where you 
 
 If you use [Claude Code](https://claude.ai/code), installing this package automatically links a set of slash commands into your project's `.claude/commands/web-fragments/` directory via a postinstall script.
 
-| Command | What it does |
-|---|---|
-| `/web-fragments:init-fragment` | Scaffolds gateway registration, app shell placeholder, and fragment HTML for a new fragment |
-| `/web-fragments:gateway-config` | Reviews or generates your `FragmentGateway` configuration and flags deprecated fields or missing error handlers |
-| `/web-fragments:debug-fragment` | Systematic diagnostic for invisible fragments, broken piercing, FOUC, and CSP/iframe blocks |
-| `/web-fragments:fragment-test` | Generates a Playwright test scenario (`index.html` + `fragment.html` + `spec.ts`) |
-| `/web-fragments:migrate-to-fragments` | Analyzes an existing app and produces a phased extraction plan |
-| `/web-fragments:fragment-csp` | Generates and audits Content Security Policy headers for the iframe-based isolation model |
-| `/web-fragments:fragment-perf` | Audits your setup for piercing, streaming, caching, and route pattern issues |
+| Command                               | What it does                                                                                                    |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `/web-fragments:init-fragment`        | Scaffolds gateway registration, app shell placeholder, and fragment HTML for a new fragment                     |
+| `/web-fragments:gateway-config`       | Reviews or generates your `FragmentGateway` configuration and flags deprecated fields or missing error handlers |
+| `/web-fragments:debug-fragment`       | Systematic diagnostic for invisible fragments, broken piercing, FOUC, and CSP/iframe blocks                     |
+| `/web-fragments:fragment-test`        | Generates a Playwright test scenario (`index.html` + `fragment.html` + `spec.ts`)                               |
+| `/web-fragments:migrate-to-fragments` | Analyzes an existing app and produces a phased extraction plan                                                  |
+| `/web-fragments:fragment-csp`         | Generates and audits Content Security Policy headers for the iframe-based isolation model                       |
+| `/web-fragments:fragment-perf`        | Audits your setup for piercing, streaming, caching, and route pattern issues                                    |
 
 The commands are discovered automatically — no manual setup required beyond having Claude Code installed.
 

--- a/packages/web-fragments/package.json
+++ b/packages/web-fragments/package.json
@@ -35,7 +35,9 @@
 	},
 	"version": "0.8.2",
 	"files": [
-		"dist"
+		"dist",
+		".claude",
+		"scripts/install-skills.js"
 	],
 	"scripts": {
 		"dev": "pnpm dev:playground",
@@ -55,7 +57,8 @@
 		"test:playground:nonpierced": "PIERCING=false pnpm -C test/playground test",
 		"test-debug:gateway": "pnpm -C test/gateway test-debug",
 		"changeset": "pnpm -C ../../ exec changeset",
-		"prepare": "pnpm build"
+		"prepare": "pnpm build",
+		"postinstall": "node scripts/install-skills.js"
 	},
 	"dependencies": {
 		"htmlrewriter": "npm:wf-htmlrewriter@0.0.13"

--- a/packages/web-fragments/scripts/install-skills.js
+++ b/packages/web-fragments/scripts/install-skills.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Postinstall script: symlinks .claude/commands/web-fragments into the
+ * consuming project's root so Claude Code discovers the web-fragments skills.
+ *
+ * Supports npm, pnpm, and yarn via the INIT_CWD environment variable.
+ */
+
+import { symlinkSync, mkdirSync, existsSync, lstatSync, unlinkSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// INIT_CWD is set by npm and pnpm to the directory where install was run.
+// Fall back to npm_config_local_prefix for older yarn versions.
+const projectRoot = process.env.INIT_CWD ?? process.env.npm_config_local_prefix;
+
+if (!projectRoot) {
+  // Running outside of a package install (e.g. direct node call) — skip silently.
+  process.exit(0);
+}
+
+// Resolve the source (skills inside this package) and the link target (in the consuming project).
+const source = resolve(__dirname, '../.claude/commands');
+const commandsDir = resolve(projectRoot, '.claude/commands');
+const target = resolve(commandsDir, 'web-fragments');
+
+// Skip if we are being installed inside our own repo (monorepo workspace install).
+if (resolve(projectRoot) === resolve(__dirname, '..')) {
+  process.exit(0);
+}
+
+try {
+  mkdirSync(commandsDir, { recursive: true });
+
+  // Remove a stale symlink or directory from a previous install.
+  if (existsSync(target) || lstatSync(target).isSymbolicLink?.()) {
+    unlinkSync(target);
+  }
+
+  symlinkSync(source, target, 'dir');
+  console.log(`[web-fragments] Claude Code skills linked → ${target}`);
+} catch (err) {
+  // Non-fatal: symlink may fail in CI or restricted environments.
+  console.warn(`[web-fragments] Could not link Claude Code skills: ${err.message}`);
+}

--- a/packages/web-fragments/scripts/install-skills.js
+++ b/packages/web-fragments/scripts/install-skills.js
@@ -17,8 +17,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = process.env.INIT_CWD ?? process.env.npm_config_local_prefix;
 
 if (!projectRoot) {
-  // Running outside of a package install (e.g. direct node call) — skip silently.
-  process.exit(0);
+	// Running outside of a package install (e.g. direct node call) — skip silently.
+	process.exit(0);
 }
 
 // Resolve the source (skills inside this package) and the link target (in the consuming project).
@@ -28,20 +28,20 @@ const target = resolve(commandsDir, 'web-fragments');
 
 // Skip if we are being installed inside our own repo (monorepo workspace install).
 if (resolve(projectRoot) === resolve(__dirname, '..')) {
-  process.exit(0);
+	process.exit(0);
 }
 
 try {
-  mkdirSync(commandsDir, { recursive: true });
+	mkdirSync(commandsDir, { recursive: true });
 
-  // Remove a stale symlink or directory from a previous install.
-  if (existsSync(target) || lstatSync(target).isSymbolicLink?.()) {
-    unlinkSync(target);
-  }
+	// Remove a stale symlink or directory from a previous install.
+	if (existsSync(target) || lstatSync(target).isSymbolicLink?.()) {
+		unlinkSync(target);
+	}
 
-  symlinkSync(source, target, 'dir');
-  console.log(`[web-fragments] Claude Code skills linked → ${target}`);
+	symlinkSync(source, target, 'dir');
+	console.log(`[web-fragments] Claude Code skills linked → ${target}`);
 } catch (err) {
-  // Non-fatal: symlink may fail in CI or restricted environments.
-  console.warn(`[web-fragments] Could not link Claude Code skills: ${err.message}`);
+	// Non-fatal: symlink may fail in CI or restricted environments.
+	console.warn(`[web-fragments] Could not link Claude Code skills: ${err.message}`);
 }


### PR DESCRIPTION
Adds 7 Claude Code slash commands (/web-fragments:init-fragment, gateway-config, debug-fragment, fragment-test, migrate-to-fragments, fragment-csp, fragment-perf) that help developers scaffold, debug, test, and migrate web-fragments projects.

Skills are auto-linked into consuming projects via a postinstall symlink script and documented in the README.

- ...

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```
