### PR TITLE
fix(reframed): make patched history properties configurable and writable

### DIFF
--- a/packages/web-fragments/src/elements/reframed/iframe-patches.ts
+++ b/packages/web-fragments/src/elements/reframed/iframe-patches.ts
@@ -160,6 +160,7 @@ export function initializeIFrameContext(
 				get() {
 					return historyProxy;
 				},
+				configurable: true,
 			},
 		});
 	} else {
@@ -180,6 +181,8 @@ export function initializeIFrameContext(
 					standaloneHistoryCursor++;
 					iframeWindow.history.replaceState(state, title, url);
 				},
+				writable: true,
+				configurable: true,
 			},
 
 			back: {
@@ -191,6 +194,8 @@ export function initializeIFrameContext(
 					let { state, title, url } = standaloneHistoryStack[standaloneHistoryCursor];
 					iframeWindow.history.replaceState(state, title, url);
 				},
+				writable: true,
+				configurable: true,
 			},
 
 			forward: {
@@ -202,12 +207,15 @@ export function initializeIFrameContext(
 					let { state, title, url } = standaloneHistoryStack[standaloneHistoryCursor];
 					iframeWindow.history.replaceState(state, title, url);
 				},
+				writable: true,
+				configurable: true,
 			},
 
 			length: {
 				get() {
 					return standaloneHistoryStack.length;
 				},
+				configurable: true,
 			},
 		});
 	}

--- a/packages/web-fragments/test/playground/location-and-history/spec.ts
+++ b/packages/web-fragments/test/playground/location-and-history/spec.ts
@@ -349,6 +349,57 @@ test('unbound fragment should not participate in history management', async () =
 	});
 });
 
+test('patched history property on bound fragment window should be configurable and re-patchable', async () => {
+	const isConfigurable = await boundContext.evaluate(() =>
+		Object.getOwnPropertyDescriptor(window, 'history')?.configurable === true,
+	);
+	expect(isConfigurable).toBe(true);
+
+	const canRedefine = await boundContext.evaluate(() => {
+		try {
+			const proxy = window.history;
+			Object.defineProperty(window, 'history', { get() { return proxy; }, configurable: true });
+			return true;
+		} catch {
+			return false;
+		}
+	});
+	expect(canRedefine).toBe(true);
+});
+
+test('patched history methods on unbound fragment should be writable, configurable, and re-patchable', async () => {
+	const descriptors = await unboundContext.evaluate(() => ({
+		pushStateWritable: Object.getOwnPropertyDescriptor(history, 'pushState')?.writable === true,
+		pushStateConfigurable: Object.getOwnPropertyDescriptor(history, 'pushState')?.configurable === true,
+		backWritable: Object.getOwnPropertyDescriptor(history, 'back')?.writable === true,
+		backConfigurable: Object.getOwnPropertyDescriptor(history, 'back')?.configurable === true,
+		forwardWritable: Object.getOwnPropertyDescriptor(history, 'forward')?.writable === true,
+		forwardConfigurable: Object.getOwnPropertyDescriptor(history, 'forward')?.configurable === true,
+		lengthConfigurable: Object.getOwnPropertyDescriptor(history, 'length')?.configurable === true,
+	}));
+
+	expect(descriptors.pushStateWritable).toBe(true);
+	expect(descriptors.pushStateConfigurable).toBe(true);
+	expect(descriptors.backWritable).toBe(true);
+	expect(descriptors.backConfigurable).toBe(true);
+	expect(descriptors.forwardWritable).toBe(true);
+	expect(descriptors.forwardConfigurable).toBe(true);
+	expect(descriptors.lengthConfigurable).toBe(true);
+
+	const canMonkeyPatch = await unboundContext.evaluate(() => {
+		try {
+			const original = history.pushState.bind(history);
+			history.pushState = function (...args) {
+				return original(...args);
+			};
+			return true;
+		} catch {
+			return false;
+		}
+	});
+	expect(canMonkeyPatch).toBe(true);
+});
+
 test('hard nav and reload behavior in a bound fragment', async ({ page }) => {
 	// cause some navigations so that we update state and can verify that we actually reloaded
 	await bound.softNavToFooButton.click();


### PR DESCRIPTION
Object.defineProperty/defineProperties defaults configurable and writable to false when not specified. Two places in iframe-patches.ts left these unset, permanently locking the patched history properties and preventing downstream frameworks or extensions from monkey-patching them after reframed runs.

- iframeWindow.history (bound path): add configurable: true
- iframeWindow.history.pushState/back/forward (unbound path): add writable: true, configurable: true
- iframeWindow.history.length (unbound path): add configurable: true

Adds two playwright tests that assert the descriptors are configurable/ writable and that monkey-patching does not throw at runtime.

# Why was the history object made unwritable and unconfigurable?

## What

Two places in `packages/web-fragments/src/elements/reframed/iframe-patches.ts` use `Object.defineProperty`/`Object.defineProperties` without explicitly setting `configurable: true` (and `writable: true` for data descriptors). Because these flags default to `false`, the patched properties end up permanently locked:

**Bound fragments** — `iframeWindow.history` property itself:
```js
Object.defineProperties(iframeWindow, {
  history: { get() { return historyProxy; } },
  // configurable: false by default — nothing can redefine window.history on the iframe
});
```

**Unbound/standalone fragments** — methods on `iframeWindow.history`:
```js
Object.defineProperties(iframeWindow.history, {
  pushState: { value: function reframedStandalonePushState... },
  // writable: false, configurable: false by default — same for back, forward, length
});
```

## When

| What | Commit | Author | Date |
|------|--------|--------|------|
| `iframeWindow.history` redirect introduced (non-configurable by default) | `928ce45` | Richard Nguyen | 2024-07-24 |
| Redirect changed to use a Proxy | `7a8f79a` | Cina Saffary | 2024-08-02 |
| Standalone `pushState/back/forward/length` overrides added (non-writable/non-configurable by default) | `b4b99bb` | Igor Minar | 2025-03-05 |

## Why

**Bound fragments (`928ce45`):**
Browsers expose a [joint session history](https://www.w3.org/TR/2011/WD-html5-20110525/history.html#joint-session-history) across all frames. If the iframe were allowed to call `history.pushState` on its own `window.history`, every navigation would create two entries — one from the iframe, one from the main window — requiring double the back/forward clicks to traverse. Redirecting `iframeWindow.history` to the main window's proxied history prevents this. The non-configurable default was **not an explicit design decision** — it's an implicit consequence of `Object.defineProperty` when `configurable` is omitted.

**Unbound/standalone fragments (`b4b99bb`):**
Standalone fragments are intentionally isolated from the shell's URL bar and browser history (chat bots, side panels, assistants). They maintain an internal history stack (`standaloneHistoryStack`) and use `replaceState` under the hood instead of `pushState` so the browser address bar is never touched. Again, the non-writable/non-configurable state is an implicit consequence of omitting the flags on `value:` descriptors.

**Related explicit fix (main window side):**
In `main-patches.ts`, the same `Object.defineProperty` on the **main window's** `history` methods is explicitly `configurable: true`, and a no-op `set: () => {}` was added (commit `9d9e047`, PR #9, 2024-07-11) because QwikCity monkey-patches `pushState`/`replaceState` after mount, causing: `TypeError: Cannot set property pushState of #<History> which only has a getter`. This fix was applied to the main window side but never carried over to the iframe side.

## Still relevant?

The architectural reason (avoiding joint session history double-entries) is still fundamental. The non-configurable side-effect is a bug, not an intention — fixed in `fix/history-properties-configurable-writable` by adding `configurable: true` and `writable: true` to all four affected descriptors.


- ...

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```
